### PR TITLE
MSP-3614: Simulation time shouldn't show viewing plan time

### DIFF
--- a/Assets/Scripts/Interface/Time Bar/TimeBar.cs
+++ b/Assets/Scripts/Interface/Time Bar/TimeBar.cs
@@ -175,7 +175,6 @@ public class TimeBar : MonoBehaviour
 	{
 		if (isViewingPlan)
 		{
-			simulationTimeText.text = Util.MonthToText(PlanManager.planViewing.StartTime);
 			planViewingText.text = Util.MonthToText(PlanManager.planViewing.StartTime, false);
 			UpdateIndicator(viewingTimeIndicatorBottom, PlanManager.planViewing.StartTime);
 		}


### PR DESCRIPTION
I think removing this line might work but I am still not 100% confident of the expected behavior and how to verify it consistently.
Still, from what I could see, I managed to verify it and should work.