### PR TITLE
fixing MSP-3421 to show KPI values even in setup phase with month -1

### DIFF
--- a/Assets/Scripts/Interface/KPI/KPICategoryPopulator.cs
+++ b/Assets/Scripts/Interface/KPI/KPICategoryPopulator.cs
@@ -200,7 +200,7 @@ public class KPICategoryPopulator: MonoBehaviour
 
 			if (bar != null)
 			{
-				bar.SetStartValue((float)value.GetKpiValueForMonth(0));
+				bar.SetStartValue((float)value.GetKpiValueForMonth(-1));
 				bar.SetActual((float)value.GetKpiValueForMonth(month), value.targetCountryId == KPIValue.CountryGlobal? 0 : value.targetCountryId);
 			}
 			else

--- a/Assets/Scripts/KPI/KPIValue.cs
+++ b/Assets/Scripts/KPI/KPIValue.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace KPI
@@ -14,7 +16,7 @@ namespace KPI
 		public readonly string unit;
 		public readonly Color graphColor;
 		public readonly int targetCountryId;
-		private readonly float[] kpiValuesPerMonth;
+		private readonly Dictionary<int, float> kpiValuesPerMonth;
 
 		public event Action<KPIValue> OnValueUpdated;
 
@@ -33,13 +35,17 @@ namespace KPI
 			graphColor = valueGraphColor;
 			this.targetCountryId = targetCountryId;
 			
-			kpiValuesPerMonth = new float[numberOfKpiMonths];
-			MostRecentMonth = 0;
+			kpiValuesPerMonth = new Dictionary<int, float>(numberOfKpiMonths);
+			for (int monthId = -1; monthId < numberOfKpiMonths-1; monthId++)
+			{
+				kpiValuesPerMonth[monthId] = 0;
+			}
+			MostRecentMonth = -1;
 		}
 
 		public void UpdateValue(int monthId, float value)
 		{
-			if (monthId >= 0 && monthId < kpiValuesPerMonth.Length)
+			if (monthId >= -1 && monthId < kpiValuesPerMonth.Count-1)
 			{
 				kpiValuesPerMonth[monthId] = value;
 				if (monthId > MostRecentMonth)
@@ -54,17 +60,17 @@ namespace KPI
 			}
 			else
 			{
-				Debug.LogWarning("Received KPI value (" + name + ") for month " + monthId + " which is out of bounds (0, " + kpiValuesPerMonth.Length + ") and has been discarded");
+				Debug.LogWarning("Received KPI value (" + name + ") for month " + monthId + " which is out of bounds (-1, " + (kpiValuesPerMonth.Count-1) + ") and has been discarded");
 			}
 		}
 
 		public float GetKpiValueForMonth(int monthId)
 		{
-			if (monthId >= 0 && monthId <= kpiValuesPerMonth.Length)
+			if (monthId >= -1 && monthId <= kpiValuesPerMonth.Count-1)
 			{
 				if (monthId > MostRecentMonth)
 				{
-					return kpiValuesPerMonth[MostRecentMonth];
+					return kpiValuesPerMonth[monthId];
 				}
 				return kpiValuesPerMonth[monthId];
 			}

--- a/Assets/Scripts/Networking/LayerImporter.cs
+++ b/Assets/Scripts/Networking/LayerImporter.cs
@@ -61,12 +61,12 @@ public class LayerImporter
         {
             TeamManager.LoadTeams();
         }
-        else
-        {
-            TeamManager.TeamsLoaded();
-        }		    
-	    
-	    //MEL config use requires layers to be loaded (for kpi creation)
+		else
+		{
+			TeamManager.TeamsLoaded();
+		}
+
+		//MEL config use requires layers to be loaded (for kpi creation)
 		NetworkForm form = new NetworkForm();
 		ServerCommunication.DoRequest<CELConfig>(Server.GetCELConfig(), form, handleCELConfigCallback);
 		ServerCommunication.DoRequest<JObject>(Server.GetMELConfig(), form, handleMELConfigCallback);
@@ -84,10 +84,10 @@ public class LayerImporter
         KPIManager.CreateEcologyKPIs(melConfig);
         PlanManager.LoadFishingFleets(melConfig);
 
-        if (loadAllLayers)
-        {
-            ImportAllLayers();
-        }
+		if (loadAllLayers)
+		{
+			ImportAllLayers();
+		}
     }
 
 	private static void handleCELConfigCallback(CELConfig config)

--- a/Assets/Scripts/Networking/LayerImporter.cs
+++ b/Assets/Scripts/Networking/LayerImporter.cs
@@ -20,6 +20,8 @@ public class LayerImporter
 	static int expectedLayers;
 	static Stopwatch stopWatch;
 
+	private static bool loadAllLayers = false;
+
 	public static bool IsCurrentlyImportingLayers 
 	{ 
 		get; 
@@ -51,8 +53,7 @@ public class LayerImporter
 		}
 		else
 		{
-			GameObject layerImporterHelper = new GameObject("LayerImporterHelper");
-			ImportAllLayers();
+			loadAllLayers = true;
 			LayerPickerUI.HideUI();
 		}
 
@@ -63,9 +64,9 @@ public class LayerImporter
         else
         {
             TeamManager.TeamsLoaded();
-        }
-
-       //MEL config use requires layers to be loaded (for kpi creation)
+        }		    
+	    
+	    //MEL config use requires layers to be loaded (for kpi creation)
 		NetworkForm form = new NetworkForm();
 		ServerCommunication.DoRequest<CELConfig>(Server.GetCELConfig(), form, handleCELConfigCallback);
 		ServerCommunication.DoRequest<JObject>(Server.GetMELConfig(), form, handleMELConfigCallback);
@@ -82,6 +83,11 @@ public class LayerImporter
     {
         KPIManager.CreateEcologyKPIs(melConfig);
         PlanManager.LoadFishingFleets(melConfig);
+
+        if (loadAllLayers)
+        {
+            ImportAllLayers();
+        }
     }
 
 	private static void handleCELConfigCallback(CELConfig config)


### PR DESCRIPTION
sorry the branch name is wrong... should be fix/MSP-3421-kpi-values-with-month-minus-one

basically I replaced a float array with a dictionary allowing it to starting indexing on -1
note the "numberOfKpiMonths" given is still respected since we only allow the dictionary to be indexed up to numberOfKpiMonths-1