### PR TITLE
abort any state active in the FSM, when switching the active layer

### DIFF
--- a/Assets/Scripts/Interface/Active Plans Window/ActivePlanLayer.cs
+++ b/Assets/Scripts/Interface/Active Plans Window/ActivePlanLayer.cs
@@ -19,9 +19,10 @@ public class ActivePlanLayer : MonoBehaviour
 		//Button callback
 		toggle.onValueChanged.AddListener((value) =>
 		{
-			if(value)
-				//PlanManager.StartEditingLayer(layer);
+			if(value) {
+				Main.FSM.AbortCurrentState();
 				InterfaceCanvas.Instance.activePlanWindow.ActivePlanLayerCallback(layer);
+			}
 		});
 	}
 


### PR DESCRIPTION
@hwarmelink this is a minor change , but needs to be tested extensively.
So any state active can be one of these:
```
Assets/Scripts/Drawing Tools/FSM/CreatePointsState.cs:public class CreatePointsState : FSMState
Assets/Scripts/Drawing Tools/FSM/CreatingLineStringState.cs:public class CreatingLineStringState : FSMState
Assets/Scripts/Drawing Tools/FSM/CreatingPolygonState.cs:public class CreatingPolygonState : FSMState
Assets/Scripts/Drawing Tools/FSM/DefaultState.cs:public class DefaultState : FSMState
Assets/Scripts/Drawing Tools/FSM/EditLineStringsState.cs:public class EditLineStringsState : FSMState
Assets/Scripts/Drawing Tools/FSM/EditPointsState.cs:public class EditPointsState : FSMState
Assets/Scripts/Drawing Tools/FSM/EditPolygonsState.cs:public class EditPolygonsState : FSMState
Assets/Scripts/Drawing Tools/FSM/InterruptStates/LayerProbeState.cs:public class LayerProbeState : FSMState
Assets/Scripts/Drawing Tools/FSM/InterruptStates/MeasurementState.cs:public class MeasurementState : FSMState
Assets/Scripts/Drawing Tools/FSM/InterruptStates/ZoomToAreaState.cs:public class ZoomToAreaState : FSMState
Assets/Scripts/Drawing Tools/FSM/SelectLineStringsState.cs:public class SelectLineStringsState : FSMState
Assets/Scripts/Drawing Tools/FSM/SelectPolygonsState.cs:public class SelectPolygonsState : FSMState
Assets/Scripts/Drawing Tools/FSM/SetOperationsState.cs:public class SetOperationsState : FSMState
Assets/Scripts/Drawing Tools/FSM/StartCreatingLineStringState.cs:public class StartCreatingLineStringState : FSMState
Assets/Scripts/Drawing Tools/FSM/StartCreatingPolygonState.cs:public class StartCreatingPolygonState : FSMState
```

if there are any states that should not be aborted on a layer switch, let me know. I can can check the current state before aborting them if necessary