### PR TITLE
Client - handling execute batches using the websocket server

### DIFF
--- a/Assets/Scripts/Data Model/PlanManager.cs
+++ b/Assets/Scripts/Data Model/PlanManager.cs
@@ -352,6 +352,11 @@ public static class PlanManager
 
 	public static EnergyGrid GetEnergyGrid(int ID)
 	{
+		if (!energyGrids.ContainsKey(ID))
+		{
+			Debug.LogError("Retrieving on non-existing key: " + ID);
+			Debug.LogError("Keys available: " + string.Join(", ", energyGrids.Keys));
+		}
 		return energyGrids[ID];
 	}
 

--- a/Assets/Scripts/Interface/Plans Monitor/Details/PlanDetailsTabDescription.cs
+++ b/Assets/Scripts/Interface/Plans Monitor/Details/PlanDetailsTabDescription.cs
@@ -63,7 +63,7 @@ public class PlanDetailsTabDescription : LockablePlanDetailsTab
 
 		lockedPlan.AttemptUnlock(batch);
 		InterfaceCanvas.ShowNetworkingBlocker();
-		batch.ExecuteBatch(HandleChangesSubmissionSuccess, HandleChangesSubmissionFailure);
+		batch.ExecuteBatchAsync(HandleChangesSubmissionSuccess, HandleChangesSubmissionFailure);
 	}
 
 	protected override void HandleChangesSubmissionSuccess(BatchRequest batch)

--- a/Assets/Scripts/Interface/Plans Monitor/Details/PlanDetailsTabDescription.cs
+++ b/Assets/Scripts/Interface/Plans Monitor/Details/PlanDetailsTabDescription.cs
@@ -57,13 +57,13 @@ public class PlanDetailsTabDescription : LockablePlanDetailsTab
 
 	protected override void SubmitChangesAndUnlock()
 	{
-		BatchRequest batch = new BatchRequest();
+		BatchRequest batch = new BatchRequest(true);
 
 		lockedPlan.SetDescription(descriptionInputField.text, batch);
 
 		lockedPlan.AttemptUnlock(batch);
 		InterfaceCanvas.ShowNetworkingBlocker();
-		batch.ExecuteBatchAsync(HandleChangesSubmissionSuccess, HandleChangesSubmissionFailure);
+		batch.ExecuteBatch(HandleChangesSubmissionSuccess, HandleChangesSubmissionFailure);
 	}
 
 	protected override void HandleChangesSubmissionSuccess(BatchRequest batch)

--- a/Assets/Scripts/Interface/Plans Monitor/Details/PlanDetailsTabLayers.cs
+++ b/Assets/Scripts/Interface/Plans Monitor/Details/PlanDetailsTabLayers.cs
@@ -302,7 +302,7 @@ public class PlanDetailsTabLayers : LockablePlanDetailsTab
 		}
 
 		lockedPlan.AttemptUnlock(batch);
-		batch.ExecuteBatch(HandleChangesSubmissionSuccess, HandleChangesSubmissionFailure);
+		batch.ExecuteBatchAsync(HandleChangesSubmissionSuccess, HandleChangesSubmissionFailure);
 	}
 
 	protected override void HandleChangesSubmissionSuccess(BatchRequest batch)

--- a/Assets/Scripts/Interface/Plans Monitor/Details/PlanDetailsTabLayers.cs
+++ b/Assets/Scripts/Interface/Plans Monitor/Details/PlanDetailsTabLayers.cs
@@ -260,7 +260,7 @@ public class PlanDetailsTabLayers : LockablePlanDetailsTab
 
 	private void SubmitChanges()
 	{
-		BatchRequest batch = new BatchRequest();
+		BatchRequest batch = new BatchRequest(true);
 		if (lockedPlan.energyPlan)
 		{
 			// Commit new grids (not distributions/sockets/sources yet)
@@ -302,7 +302,7 @@ public class PlanDetailsTabLayers : LockablePlanDetailsTab
 		}
 
 		lockedPlan.AttemptUnlock(batch);
-		batch.ExecuteBatchAsync(HandleChangesSubmissionSuccess, HandleChangesSubmissionFailure);
+		batch.ExecuteBatch(HandleChangesSubmissionSuccess, HandleChangesSubmissionFailure);
 	}
 
 	protected override void HandleChangesSubmissionSuccess(BatchRequest batch)

--- a/Assets/Scripts/Main.cs
+++ b/Assets/Scripts/Main.cs
@@ -79,7 +79,7 @@ public class Main : MonoBehaviour
 				NetworkForm form = new NetworkForm();
 				form.AddField("session_id", TeamManager.CurrentSessionID);
 				ServerCommunication.DoPriorityRequest(Server.CloseSession(), form, CloseSessionSuccess, CloseSessionFail);
-				UpdateData.WsServerCommunication?.Stop();
+				UpdateData.WsServerCommunicationInteractor?.Stop();
 				//StartCoroutine(QuitAtEndOfFrame());
 			}
             return !interceptQuit;
@@ -111,7 +111,7 @@ public class Main : MonoBehaviour
 			NetworkForm form = new NetworkForm();
 			form.AddField("session_id", TeamManager.CurrentSessionID);
 			ServerCommunication.DoPriorityRequest(Server.CloseSession(), form, instance.CloseSessionSuccess, instance.CloseSessionFail);
-			UpdateData.WsServerCommunication?.Stop();
+			UpdateData.WsServerCommunicationInteractor?.Stop();
 		}
 		else
 		{

--- a/Assets/Scripts/Main.cs
+++ b/Assets/Scripts/Main.cs
@@ -79,7 +79,7 @@ public class Main : MonoBehaviour
 				NetworkForm form = new NetworkForm();
 				form.AddField("session_id", TeamManager.CurrentSessionID);
 				ServerCommunication.DoPriorityRequest(Server.CloseSession(), form, CloseSessionSuccess, CloseSessionFail);
-				UpdateData.StopWsServerCommunication();
+				UpdateData.WsServerCommunication?.Stop();
 				//StartCoroutine(QuitAtEndOfFrame());
 			}
             return !interceptQuit;
@@ -111,7 +111,7 @@ public class Main : MonoBehaviour
 			NetworkForm form = new NetworkForm();
 			form.AddField("session_id", TeamManager.CurrentSessionID);
 			ServerCommunication.DoPriorityRequest(Server.CloseSession(), form, instance.CloseSessionSuccess, instance.CloseSessionFail);
-			UpdateData.StopWsServerCommunication();
+			UpdateData.WsServerCommunication?.Stop();
 		}
 		else
 		{

--- a/Assets/Scripts/Networking/BatchRequest.cs
+++ b/Assets/Scripts/Networking/BatchRequest.cs
@@ -40,8 +40,9 @@ public class BatchRequest
 	private Action<BatchRequest> m_failureCallback;
 	private Action<BatchRequest> m_successCallback;
 
-	public BatchRequest()
+	public BatchRequest(bool async = false)
 	{
+		m_async = async;
 		m_callbacks = new Dictionary<int, ITypedCallback>();
 		m_callQueue = new List<QueuedBatchCall>();
 		m_outstandingCallRequests = new HashSet<int>();
@@ -75,7 +76,7 @@ public class BatchRequest
 			m_status = EBatchStatus.Failed;
 			if (m_executeWhenReady)
 			{
-				ExecuteBatch(m_async);
+				ExecuteBatch();
 			}
 		}
 	}
@@ -139,7 +140,7 @@ public class BatchRequest
 
 		if (m_executeWhenReady && m_outstandingCallRequests.Count == 0)
 		{
-			ExecuteBatch(m_async);
+			ExecuteBatch();
 		}
 	}
 
@@ -155,7 +156,7 @@ public class BatchRequest
 			m_status = EBatchStatus.Failed;
 			if (m_executeWhenReady)
 			{
-				ExecuteBatch(m_async);
+				ExecuteBatch();
 			}
 		}
 	}
@@ -167,16 +168,8 @@ public class BatchRequest
 		ExecuteBatch();
 	}
 
-	public void ExecuteBatchAsync(Action<BatchRequest> successCallback, Action<BatchRequest> failureCallback)
+	private void ExecuteBatch()
 	{
-		this.m_successCallback = successCallback;
-		this.m_failureCallback = failureCallback;
-		ExecuteBatch(true);
-	}
-
-	private void ExecuteBatch(bool async = false)
-	{
-		m_async = async;
 		if (m_status == EBatchStatus.Failed)
 		{
 			UpdateData.WsServerCommunicationInteractor?.UnregisterBatchRequestCallbacks(m_batchID);
@@ -209,8 +202,6 @@ public class BatchRequest
 				ServerCommunication.DoRequest<BatchExecutionResult>(Server.ExecuteBatch(), form, HandleBatchSuccess,
 					HandleBatchFailure);
 			}
-
-			m_async = false; // reset to default, no async.
 		}
 		else
 		{

--- a/Assets/Scripts/Networking/ServerCommunication.cs
+++ b/Assets/Scripts/Networking/ServerCommunication.cs
@@ -84,6 +84,7 @@ public static class ServerCommunication
 
 	public class RequestResult
 	{
+		public string type;
 		public bool success;
 		public string message;
 		public JToken payload; 

--- a/Assets/Scripts/Networking/ServerCommunication.cs
+++ b/Assets/Scripts/Networking/ServerCommunication.cs
@@ -84,7 +84,8 @@ public static class ServerCommunication
 
 	public class RequestResult
 	{
-		public string type;
+		public string header_type;
+		public JToken header_data;
 		public bool success;
 		public string message;
 		public JToken payload; 
@@ -222,7 +223,7 @@ public static class ServerCommunication
 	}
 	
 	//Note: specifying a custom failure callback avoids all default ones, including automatic retries.
-	public static void DoRequest<T>(string url, NetworkForm form, Action<T> successCallback, System.Action<ARequest, string> failureCallback, int retriesOnFail = 3)
+	public static ARequest DoRequest<T>(string url, NetworkForm form, Action<T> successCallback, System.Action<ARequest, string> failureCallback, int retriesOnFail = 3)
 	{
 		ARequest request = new FormRequest<T>(Server.Url + url, (form != null) ? form.Form : null, successCallback, failureCallback, retriesOnFail);
 		requestsQueue.Enqueue(request);
@@ -231,31 +232,30 @@ public static class ServerCommunication
 		{
 			OnRequestQueued(request);
 		}
+
+		return request;
 	}
 
-	public static void DoRequest<T>(string url, NetworkForm form, Action<T> successCallback, EWebRequestFailureResponse responseType = EWebRequestFailureResponse.Error, int retriesOnFail = 3)
+	public static ARequest DoRequest<T>(string url, NetworkForm form, Action<T> successCallback, EWebRequestFailureResponse responseType = EWebRequestFailureResponse.Error, int retriesOnFail = 3)
 	{
 		switch(responseType)
 		{
 			case EWebRequestFailureResponse.Error:
-				DoRequest<T>(url, form, successCallback, HandleRequestFailureError, retriesOnFail);
-				break;
+				return DoRequest<T>(url, form, successCallback, HandleRequestFailureError, retriesOnFail);
 			case EWebRequestFailureResponse.Crash:
-				DoRequest<T>(url, form, successCallback, HandleRequestFailureCrash, retriesOnFail);
-				break;
+				return DoRequest<T>(url, form, successCallback, HandleRequestFailureCrash, retriesOnFail);
 			default:
-				DoRequest<T>(url, form, successCallback, HandleRequestFailureLog, retriesOnFail);
-				break;
+				return DoRequest<T>(url, form, successCallback, HandleRequestFailureLog, retriesOnFail);
 		}
 	}
 
-	public static void DoRequest(string url, NetworkForm form, int retriesOnFail = 3)
+	public static ARequest DoRequest(string url, NetworkForm form, int retriesOnFail = 3)
 	{
-		DoRequest<string>(url, form, null, HandleRequestFailureError, retriesOnFail);
+		return DoRequest<string>(url, form, null, HandleRequestFailureError, retriesOnFail);
 	}
 
 	//Note: specifying a custom failure callback avoids all default ones, including automatic retries.
-	public static void DoRequest<T>(string url, string rawData, Action<T> successCallback, System.Action<ARequest, string> failureCallback, int retriesOnFail = 0)
+	public static ARequest DoRequest<T>(string url, string rawData, Action<T> successCallback, System.Action<ARequest, string> failureCallback, int retriesOnFail = 0)
     {
         ARequest request = new RawDataRequest<T>(Server.Url + url, rawData, successCallback, failureCallback, retriesOnFail);
         requestsQueue.Enqueue(request);
@@ -264,27 +264,26 @@ public static class ServerCommunication
         {
             OnRequestQueued(request);
         }
+
+        return request;
     }
 
-	public static void DoRequest<T>(string url, string rawData, Action<T> successCallback, EWebRequestFailureResponse responseType, int retriesOnFail = 0)
+	public static ARequest DoRequest<T>(string url, string rawData, Action<T> successCallback, EWebRequestFailureResponse responseType, int retriesOnFail = 0)
 	{
 		switch (responseType)
 		{
 			case EWebRequestFailureResponse.Error:
-				DoRequest<T>(url, rawData, successCallback, HandleRequestFailureError, retriesOnFail);
-				break;
+				return DoRequest<T>(url, rawData, successCallback, HandleRequestFailureError, retriesOnFail);
 			case EWebRequestFailureResponse.Crash:
-				DoRequest<T>(url, rawData, successCallback, HandleRequestFailureCrash, retriesOnFail);
-				break;
+				return DoRequest<T>(url, rawData, successCallback, HandleRequestFailureCrash, retriesOnFail);
 			default:
-				DoRequest<T>(url, rawData, successCallback, HandleRequestFailureLog, retriesOnFail);
-				break;
+				return DoRequest<T>(url, rawData, successCallback, HandleRequestFailureLog, retriesOnFail);
 		}
 	}
 
-	public static void DoRequest(string url, string rawData, EWebRequestFailureResponse responseType = EWebRequestFailureResponse.Error, int retriesOnFail = 3)
+	public static ARequest DoRequest(string url, string rawData, EWebRequestFailureResponse responseType = EWebRequestFailureResponse.Error, int retriesOnFail = 3)
 	{
-		DoRequest<string>(url, rawData, null, HandleRequestFailureError, retriesOnFail);
+		return DoRequest<string>(url, rawData, null, HandleRequestFailureError, retriesOnFail);
 	}
 
 	public static void DoExternalAPICall<T>(string url, Dictionary<int, SubEntity> subEntitiesToPass, Action<T> successCallback, System.Action<ARequest, string> failureCallback, int retriesOnFail = 0)

--- a/Assets/Scripts/Networking/WsServerCommunication.cs
+++ b/Assets/Scripts/Networking/WsServerCommunication.cs
@@ -153,6 +153,7 @@ namespace Networking
 		{
 			UnregisterBatchRequestCallbacks(batchId);
 			m_BatchRequestSuccessCallbacks.Add(batchId, successCallback);
+			m_BatchRequestFailureCallbacks.Add(batchId, failureCallback);
 		}
 
 		public void UnregisterBatchRequestCallbacks(int batchId)
@@ -160,6 +161,10 @@ namespace Networking
 			if (m_BatchRequestSuccessCallbacks.ContainsKey(batchId))
 			{
 				m_BatchRequestSuccessCallbacks.Remove(batchId);
+			}
+			if (m_BatchRequestFailureCallbacks.ContainsKey(batchId))
+			{
+				m_BatchRequestFailureCallbacks.Remove(batchId);
 			}
 		}
 
@@ -231,6 +236,8 @@ namespace Networking
 			}
 			catch (System.Exception e)
 			{
+				Debug.LogError("Exception in ProcessGameLatestPayload: " + e.Message + "\n" + e.StackTrace);
+				Debug.LogError("update payload: " + result.payload);
 				// do not update lastUpdateTimestamp and do not process payload
 				return;
 			}

--- a/Assets/Scripts/Networking/WsServerConnectionChangeBehaviour/WsServerConnectionChangeBehaviour.cs
+++ b/Assets/Scripts/Networking/WsServerConnectionChangeBehaviour/WsServerConnectionChangeBehaviour.cs
@@ -6,21 +6,23 @@ namespace Networking.WsServerConnectionChangeBehaviour
 	{
 		private void OnEnable()
 		{
-			if (UpdateData.WsServerCommunication?.IsConnected == null)
+			bool? connected = UpdateData.WsServerCommunicationInteractor?.IsConnected();
+			if (connected == null)
 			{
 				return;
 			}
-			NotifyConnection(UpdateData.WsServerCommunication.IsConnected.Value);
+			NotifyConnection(connected.Value);
 		}
 
 		private void Start()
 		{
 			OnStart();
-			if (UpdateData.WsServerCommunication?.IsConnected == null)
+			bool? connected = UpdateData.WsServerCommunicationInteractor?.IsConnected();
+			if (connected == null)
 			{
 				return;
 			}
-			NotifyConnection(UpdateData.WsServerCommunication.IsConnected.Value);
+			NotifyConnection(connected.Value);
 		}
 
 		public void NotifyConnection(bool a_Connected)

--- a/Assets/Scripts/Networking/WsServerConnectionChangeBehaviour/WsServerConnectionChangeBehaviour.cs
+++ b/Assets/Scripts/Networking/WsServerConnectionChangeBehaviour/WsServerConnectionChangeBehaviour.cs
@@ -6,21 +6,21 @@ namespace Networking.WsServerConnectionChangeBehaviour
 	{
 		private void OnEnable()
 		{
-			if (UpdateData.WsServerConnected == null)
+			if (UpdateData.WsServerCommunication?.IsConnected == null)
 			{
 				return;
 			}
-			NotifyConnection(UpdateData.WsServerConnected.Value);
+			NotifyConnection(UpdateData.WsServerCommunication.IsConnected.Value);
 		}
 
 		private void Start()
 		{
 			OnStart();
-			if (UpdateData.WsServerConnected == null)
+			if (UpdateData.WsServerCommunication?.IsConnected == null)
 			{
 				return;
 			}
-			NotifyConnection(UpdateData.WsServerConnected.Value);
+			NotifyConnection(UpdateData.WsServerCommunication.IsConnected.Value);
 		}
 
 		public void NotifyConnection(bool a_Connected)


### PR DESCRIPTION
* StartBatch call requires you to send country - and user id now, to be able to identify the batch "owner"
* ExecuteBatch has an option "async" now. If enabled it will call ExecuteBatch on the api server as normal, but not await any response. It will register callback functions to WsServerCommunication, since the result of the ExecuteBatch call will be received by websocket connection, and it will be able to call one of those callback functions to let the "caller" now about it.
* Fixed some coded styling here and there
* PlanDetailsTabLayer runs the ExecuteBatchAsync now. All possible tasks on the server side have been made asynchronous.
* removed Hide- and ShowDisconnectionDialogBox from UpdateData, not needed or used. Please double check this @HutchinsonKevin ..

bit of re-factor to control the usage of WsServerCommunication though a interface, which instance is owned by UpdateData class:
* created interface for WsServerCommunication called -Interactor to interact, e.g. start, stop, (un)register callbacks, retrieve IsConnected. UpdateData::m_WsServerCommunication is private now (was WsServerCommunication).
* create a public accessible WsServerCommunicationInteractor instance accessible from the static UpdateData class.
* there was no more need to UpdateData's WsServerConnected public member, it is private now, and is used to detected connection changes only. Also StopWsServerCommunication has been replaced by WsServerCommunicationInteractor?.Stop
* UpdateData is now also responsible for updating WsServerCommunication, calling WsServerCommunication::Update()
* simplified UpdateData's GetUpdates. ProcessUpdates will only do something when m_NextUpdates has items, not need to added this into the main while loop. Added new m_WsServerCommunication's Update there.
* m_WsServerCommunication::Update handles the processing van batch request results.

extends on WsServerCommunication:
* recognizing and processing messages with the result of ExecuteBatch
* RequestResult has been extended with "header_type" and "header_data". Note that messages from the websocket can not have headers. Headers are only available on the connection itself. So to be able to identify what kind of message its receives the server will set these additional fields. These fields will be always be null when a request result comes from the api. So they are only set by the websocket server
* WsServerCommunication has a switch on the message header_type now
* For message type "Batch/ExecuteBatch" the header_data will hold the batch id

extends on ServerCommunication:
* Added failure handling for batch requests when executed async. Requires ServerCommunication to return ARequest when calling DoRequest directly instead of passing it to the failure callback only