### PR TITLE
[MSP-3856] Implement link between GitHub and Jira

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,3 @@
-## Jira issue number
-MSP-
-
-## Describe your changes
-
 ## Checklist before requesting a review
 - [ ] I am using the Jira issue number in the commit message.
 - [ ] The branch is named as the Jira issue number.

--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,5 @@
+## Jira issue number
+MSP-
+
+## Describe your changes
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # MSPChallenge-Client
+
+## Contribution rules
+- Any contribution to the project must be proposed through a Pull Request.
+- All Pull Requests need to be reviewed by at least one member of the MSP development team before being merged.
+- Remember to put the Jira issue number in the commit message.
+- Set _.gitmessage_ as your commit message template by running the following command from git bash:
+```sh
+ git config commit.template .gitmessage
+```


### PR DESCRIPTION
[MSP-3856] Implement link between GitHub and Jira
Adding default commit message to the repository
Updating readme.md with contribution instructions
Reduced the PR templated message

## Checklist before requesting a review
- [x] I am using the Jira issue number in the commit message.
- [x] The branch is named as the Jira issue number.
