### PR TITLE
A lesser dependent client "Play" countdown time

### DIFF
--- a/Assets/Scripts/Interface/Time Manager/TimeManager.cs
+++ b/Assets/Scripts/Interface/Time Manager/TimeManager.cs
@@ -7,128 +7,143 @@ public class TimeManager : MonoBehaviour
 {
 	private const int ERA_COUNT = 4;
 
-    private static TimeManager singleton;
+	private static TimeManager singleton;
 
-    public static TimeManager instance
-    {
-        get
-        {
-            if (singleton == null)
-                singleton = (TimeManager)FindObjectOfType(typeof(TimeManager));
-            return singleton;
-        }
-    }
-    
-    private int era = 0;
-    public int Era { get { return era; } }
-    private int[] eraRealTimes = new int[ERA_COUNT];
-    private int eraGameTime = 0;
-    int timeLeft = 0;
-    //int timeBeforeForwarding = -1; //if not -1, we are forwarding and the number is the realtime before forwarding
+	public static TimeManager instance
+	{
+		get
+		{
+			if (singleton == null)
+				singleton = (TimeManager)FindObjectOfType(typeof(TimeManager));
+			return singleton;
+		}
+	}
 
-    public void UpdateUI(TimelineState timeState)
-    {
-        //Use month
-        int month = GameState.GetCurrentMonth();
-        TimeManagerWindow.instance.timeline.Progress = (float)month / (float)Main.MspGlobalData.session_end_month;
+	private int era = 0;
+	public int Era { get { return era; } }
+	private int[] eraRealTimes = new int[ERA_COUNT];
+	private int eraGameTime = 0;
+	int timeLeft = 0;
+	//int timeBeforeForwarding = -1; //if not -1, we are forwarding and the number is the realtime before forwarding
+
+	private float m_timeLeftElapsed = 0f;
+
+	public void Update()
+	{
+		if (GameState.CurrentState != GameState.PlanningState.Play)
+		{
+			return;
+		}
+
+		m_timeLeftElapsed += Time.deltaTime;
+		EraHUD.instance.TimeRemaining = TimeSpan.FromSeconds(timeLeft - (int)m_timeLeftElapsed);
+	}
+
+	public void UpdateUI(TimelineState timeState)
+	{
+		m_timeLeftElapsed = 0f;
+
+		//Use month
+		int month = GameState.GetCurrentMonth();
+		TimeManagerWindow.instance.timeline.Progress = (float)month / (float)Main.MspGlobalData.session_end_month;
 
 		//Era change
 		int newEra = Math.Min(Mathf.FloorToInt(month / (float)Main.MspGlobalData.era_total_months), ERA_COUNT - 1);
-        if (newEra != era)
-        {
-            for (int i = era; i < newEra; i++)
-            {
-                TimeManagerWindow.instance.timeline.eraBlocks[i].IsActive = false;
-            }
-            era = newEra;
-        }      
+		if (newEra != era)
+		{
+			for (int i = era; i < newEra; i++)
+			{
+				TimeManagerWindow.instance.timeline.eraBlocks[i].IsActive = false;
+			}
+			era = newEra;
+		}
 
-        //Era realtime
-        string[] planningTimes = timeState.planning_era_realtime.Split(',');
-        for (int i = era + 1; i < ERA_COUNT; i++)
-        {
-            int newEraTime = Util.ParseToInt(planningTimes[i]);
-            if (newEraTime != eraRealTimes[i])
-            {
-                TimeManagerWindow.instance.timeline.eraBlocks[i].SetDurationUI(TimeSpan.FromSeconds(newEraTime));
-                eraRealTimes[i] = newEraTime;
-            }
-        }
+		//Era realtime
+		string[] planningTimes = timeState.planning_era_realtime.Split(',');
+		for (int i = era + 1; i < ERA_COUNT; i++)
+		{
+			int newEraTime = Util.ParseToInt(planningTimes[i]);
+			if (newEraTime != eraRealTimes[i])
+			{
+				TimeManagerWindow.instance.timeline.eraBlocks[i].SetDurationUI(TimeSpan.FromSeconds(newEraTime));
+				eraRealTimes[i] = newEraTime;
+			}
+		}
 
-        //Current era realtime
-        if (timeState.era_realtime != null)
-        {
-            int newEraTime = Util.ParseToInt(timeState.era_realtime);
-            if (eraRealTimes[era] != newEraTime)
-            {
-                eraRealTimes[era] = newEraTime;
-                TimeSpan newTimeSpan = TimeSpan.FromSeconds(newEraTime);
-                if (!GameState.GameStarted)
-                {
-                    EraHUD.instance.TimeRemaining = newTimeSpan;
-                    TimeManagerWindow.instance.timeline.eraBlocks[era].SetDurationUI(newTimeSpan);
-                }
-            }
-        }
+		//Current era realtime
+		if (timeState.era_realtime != null)
+		{
+			int newEraTime = Util.ParseToInt(timeState.era_realtime);
+			if (eraRealTimes[era] != newEraTime)
+			{
+				eraRealTimes[era] = newEraTime;
+				TimeSpan newTimeSpan = TimeSpan.FromSeconds(newEraTime);
+				if (!GameState.GameStarted)
+				{
+					EraHUD.instance.TimeRemaining = newTimeSpan;
+					TimeManagerWindow.instance.timeline.eraBlocks[era].SetDurationUI(newTimeSpan);
+				}
+			}
+		}
 
-        //Era gametime
-        if (timeState.era_gametime != null)
-        {
-            int newGameTime = Util.ParseToInt(timeState.era_gametime);
-            if (eraGameTime != newGameTime)
-            {
-                float division = 1f - ((float)newGameTime / (float)Main.MspGlobalData.era_total_months);
-                for (int i = 0; i < ERA_COUNT; i++)
-                {
-                    TimeManagerWindow.instance.eraDivision.SetEraSimulationDivision(i, division);
-                    TimeBar.instance.markers[i].eraSimMarker.rectTransform.sizeDelta = new Vector2((TimeBar.instance.eraMarkerLocation.rect.width / (float)ERA_COUNT) * division, 4f);
-                }
-                TimeManagerWindow.instance.eraDivision.SetSliderValue(newGameTime / 12);
-                eraGameTime = newGameTime;             
-            }
-        }
+		//Era gametime
+		if (timeState.era_gametime != null)
+		{
+			int newGameTime = Util.ParseToInt(timeState.era_gametime);
+			if (eraGameTime != newGameTime)
+			{
+				float division = 1f - ((float)newGameTime / (float)Main.MspGlobalData.era_total_months);
+				for (int i = 0; i < ERA_COUNT; i++)
+				{
+					TimeManagerWindow.instance.eraDivision.SetEraSimulationDivision(i, division);
+					TimeBar.instance.markers[i].eraSimMarker.rectTransform.sizeDelta = new Vector2((TimeBar.instance.eraMarkerLocation.rect.width / (float)ERA_COUNT) * division, 4f);
+				}
+				TimeManagerWindow.instance.eraDivision.SetSliderValue(newGameTime / 12);
+				eraGameTime = newGameTime;
+			}
+		}
 
-        //Remaining time
-        if (timeState.era_timeleft != null)
-        {
-            int newTimeLeft = (int)Util.ParseToFloat(timeState.era_timeleft);
-            if (timeLeft != newTimeLeft)
-            {
-                if (newTimeLeft < 0)
-                {
-                    EraHUD.instance.CatchingUp = true;
-                }
-                else
-                {
-                    if (timeLeft < 0)
-                        EraHUD.instance.CatchingUp = false;
-                    TimeSpan newTimeSpan = TimeSpan.FromSeconds(newTimeLeft);                   
-                    if (GameState.GameStarted)
-                    {
-                        EraHUD.instance.TimeRemaining = newTimeSpan;
-                        TimeManagerWindow.instance.timeline.eraBlocks[era].SetDurationUI(newTimeSpan);
-                    }
-                }
-                timeLeft = newTimeLeft;
-            }
-        }
-    }
+		//Remaining time
+		if (timeState.era_timeleft != null)
+		{
+			int newTimeLeft = (int)Util.ParseToFloat(timeState.era_timeleft);
+			if (timeLeft != newTimeLeft)
+			{
+				if (newTimeLeft < 0)
+				{
+					EraHUD.instance.CatchingUp = true;
+				}
+				else
+				{
+					if (timeLeft < 0)
+						EraHUD.instance.CatchingUp = false;
+					TimeSpan newTimeSpan = TimeSpan.FromSeconds(newTimeLeft);
+					if (GameState.GameStarted)
+					{
+						EraHUD.instance.TimeRemaining = newTimeSpan;
+						TimeManagerWindow.instance.timeline.eraBlocks[era].SetDurationUI(newTimeSpan);
+					}
+				}
+				timeLeft = newTimeLeft;
+			}
+		}
+	}
 
 	public void SetupStateEntered()
 	{
-        TimeManagerWindow.instance.eraDivision.gameObject.SetActive(true);
-        TimeManagerWindow.instance.controls.SetGlowTo(TimeManagerControls.TimeControlButton.Pause);
+		TimeManagerWindow.instance.eraDivision.gameObject.SetActive(true);
+		TimeManagerWindow.instance.controls.SetGlowTo(TimeManagerControls.TimeControlButton.Pause);
 	}
 
 	public void PauseStateEntered()
-    {
-        TimeManagerWindow.instance.controls.SetGlowTo(TimeManagerControls.TimeControlButton.Pause);
-    }
+	{
+		TimeManagerWindow.instance.controls.SetGlowTo(TimeManagerControls.TimeControlButton.Pause);
+	}
 
-    public void PlayStateEntered()
-    {
-        TimeManagerWindow.instance.controls.SetGlowTo(TimeManagerControls.TimeControlButton.Play);
-    }
+	public void PlayStateEntered()
+	{
+		TimeManagerWindow.instance.controls.SetGlowTo(TimeManagerControls.TimeControlButton.Play);
+	}
 
 	public void FastForwardStateEntered()
 	{
@@ -138,15 +153,15 @@ public class TimeManager : MonoBehaviour
 	public void SimulationStateEntered()
 	{
 		TimeManagerWindow.instance.timeline.eraBlocks[era].IsActive = false;
-        TimeManagerWindow.instance.controls.Interactable = false;
-        TimeManagerWindow.instance.controls.SetGlowTo(TimeManagerControls.TimeControlButton.Play);
-        //timeBeforeForwarding = -1;
-    }
+		TimeManagerWindow.instance.controls.Interactable = false;
+		TimeManagerWindow.instance.controls.SetGlowTo(TimeManagerControls.TimeControlButton.Play);
+		//timeBeforeForwarding = -1;
+	}
 
-    public void SimulationStateExited()
-    {
-        TimeManagerWindow.instance.controls.Interactable = true;
-    }
+	public void SimulationStateExited()
+	{
+		TimeManagerWindow.instance.controls.Interactable = true;
+	}
 
 	public void SetupStateExited()
 	{
@@ -170,87 +185,87 @@ public class TimeManager : MonoBehaviour
 		}
 	}
 
-    public void Play()
-    {
-        //if (timeBeforeForwarding != -1)//If we were forwarding, go back to previous speed
-        //{
-        //    ServerChangePlanningRealTime(timeBeforeForwarding);
-        //    timeBeforeForwarding = -1;
-        //    //TimeManagerWindow.instance.controls.SetGlowTo(TimeManagerControls.TimeControlButton.Play);
-        //}
-        //else
-        //{
+	public void Play()
+	{
+		//if (timeBeforeForwarding != -1)//If we were forwarding, go back to previous speed
+		//{
+		//    ServerChangePlanningRealTime(timeBeforeForwarding);
+		//    timeBeforeForwarding = -1;
+		//    //TimeManagerWindow.instance.controls.SetGlowTo(TimeManagerControls.TimeControlButton.Play);
+		//}
+		//else
+		//{
 			GameState.SetGameState(GameState.PlanningStateToString(GameState.PlanningState.Play));
-        //}
-    }
+		//}
+	}
 
-    public void Pause()
-    {
+	public void Pause()
+	{
 		GameState.SetGameState(GameState.PlanningStateToString(GameState.PlanningState.Pause));
 	}
 
-    public void Forward()
-    {
-        // Dialog Box
-        string title = "Advancing Game Time";
-        string description = "Advancing the game time will finish the current era and advance the game time to the next era.\n\nAre you sure you want to do this?";
-        UnityEngine.Events.UnityAction lb = new UnityEngine.Events.UnityAction(() => { });
-        UnityEngine.Events.UnityAction rb = new UnityEngine.Events.UnityAction(() => {
-            //ServerChangePlanningRealTime(0);
-            //timeBeforeForwarding = eraRealTimes[era];
+	public void Forward()
+	{
+		// Dialog Box
+		string title = "Advancing Game Time";
+		string description = "Advancing the game time will finish the current era and advance the game time to the next era.\n\nAre you sure you want to do this?";
+		UnityEngine.Events.UnityAction lb = new UnityEngine.Events.UnityAction(() => { });
+		UnityEngine.Events.UnityAction rb = new UnityEngine.Events.UnityAction(() => {
+			//ServerChangePlanningRealTime(0);
+			//timeBeforeForwarding = eraRealTimes[era];
 			//TimeManagerWindow.instance.controls.SetGlowTo(TimeManagerControls.TimeControlButton.Forward);
 			GameState.SetGameState(GameState.PlanningStateToString(GameState.PlanningState.FastForward));
 		});
-        DialogBoxManager.instance.ConfirmationWindow(title, description, lb, rb);
-    }
+		DialogBoxManager.instance.ConfirmationWindow(title, description, lb, rb);
+	}
 
-    public void Restart()
-    {
-        // Dialog Box
-        //string title = "Reset Game Time";
-        //string description = "Resetting game time will restart the game from 2010 with the current game settings.\n\nAre you sure you want to do this?";
-        //UnityEngine.Events.UnityAction lb = new UnityEngine.Events.UnityAction(() => { });
-        //UnityEngine.Events.UnityAction rb = new UnityEngine.Events.UnityAction(() => {
+	public void Restart()
+	{
+		// Dialog Box
+		//string title = "Reset Game Time";
+		//string description = "Resetting game time will restart the game from 2010 with the current game settings.\n\nAre you sure you want to do this?";
+		//UnityEngine.Events.UnityAction lb = new UnityEngine.Events.UnityAction(() => { });
+		//UnityEngine.Events.UnityAction rb = new UnityEngine.Events.UnityAction(() => {
 
-        //});
+		//});
 
-        //DialogBox box = DialogBoxManager.instance.ConfirmationWindow(title, description, lb, rb);
+		//DialogBox box = DialogBoxManager.instance.ConfirmationWindow(title, description, lb, rb);
 
-        //Debug.Log("TimeManager: Reset");
-    }
+		//Debug.Log("TimeManager: Reset");
+	}
 
-    public void RemainingTimeChanged(int newSeconds)
-    {
-        if(GameState.GameStarted)
-            ServerChangePlanningRealTime(newSeconds + (eraRealTimes[era] - timeLeft));
-        else
-            ServerChangePlanningRealTime(newSeconds);
-        //ServerChangeRemainingTime(newSeconds);
-    }
+	public void RemainingTimeChanged(int newSeconds)
+	{
+		if(GameState.GameStarted)
+			ServerChangePlanningRealTime(newSeconds + (eraRealTimes[era] - timeLeft));
+		else
+			ServerChangePlanningRealTime(newSeconds);
+		//ServerChangeRemainingTime(newSeconds);
+	}
 
-    public void EraRealTimeChanged(int eraChanged, TimeSpan newDuration)
-    {
-        if (eraChanged < era)
-            return;
-        if (eraChanged == era)
-        {
-            //Change remaining time
-            int monthsLeft = eraGameTime - (GameState.GetCurrentMonth() % Main.MspGlobalData.era_total_months);
-            if (monthsLeft == 0)
-                Debug.LogError("Era should have passed, but didn't. Causing divide by 0.");
-            else if(monthsLeft < 0)
-                Debug.LogError("Tried to change planning time in simulation phase");
+	public void EraRealTimeChanged(int eraChanged, TimeSpan newDuration)
+	{
+		if (eraChanged < era)
+			return;
+		if (eraChanged == era)
+		{
+			//Change remaining time
+			int monthsLeft = eraGameTime - (GameState.GetCurrentMonth() % Main.MspGlobalData.era_total_months);
+			if (monthsLeft == 0)
+				Debug.LogError("Era should have passed, but didn't. Causing divide by 0.");
+			else if(monthsLeft < 0)
+				Debug.LogError("Tried to change planning time in simulation phase");
 
-            ServerChangePlanningRealTime(Mathf.CeilToInt((float)newDuration.TotalSeconds / ((float)monthsLeft / (float)eraGameTime)));
-            //ServerChangePlanningRealTime((int)newDuration.TotalSeconds + (eraRealTimes[era] - timeLeft));
-        }
-        else
-        {
-            //Change future realtime
-            eraRealTimes[eraChanged] = (int)newDuration.TotalSeconds;
-            ServerChangeAllPlanningRealTime();
-        }   
-    }
+			ServerChangePlanningRealTime(Mathf.CeilToInt((float)newDuration.TotalSeconds / ((float)monthsLeft / (float)eraGameTime)));
+			//ServerChangePlanningRealTime((int)newDuration.TotalSeconds + (eraRealTimes[era] - timeLeft));
+		}
+		else
+		{
+			//Change future realtime
+			eraRealTimes[eraChanged] = (int)newDuration.TotalSeconds;
+			ServerChangeAllPlanningRealTime();
+		}
+	}
 
 	public void SetEraRealtimeValues(int[] eraTimesInSeconds)
 	{
@@ -267,18 +282,18 @@ public class TimeManager : MonoBehaviour
 	}
 
 	public void EraGameTimeChanged(int value)
-    {
-        ServerChangePlanningGameTime(value);
-    }
+	{
+		ServerChangePlanningGameTime(value);
+	}
 
-    #region ServerCommunication
+	#region ServerCommunication
 
-    private void ServerSetGameState(GameState.PlanningState state)
-    {
-        NetworkForm form = new NetworkForm();
-        form.AddField("state", state.ToString());
-        ServerCommunication.DoRequest(Server.SetGameState(), form);
-    }
+	private void ServerSetGameState(GameState.PlanningState state)
+	{
+		NetworkForm form = new NetworkForm();
+		form.AddField("state", state.ToString());
+		ServerCommunication.DoRequest(Server.SetGameState(), form);
+	}
 
 	private void ServerChangePlanningGameTime(int newMonths)
 	{
@@ -290,37 +305,37 @@ public class TimeManager : MonoBehaviour
 
 		NetworkForm form = new NetworkForm();
 		form.AddField("months", newMonths);
-        ServerCommunication.DoRequest(Server.SetGamePlanningTime(), form);
-    }
+		ServerCommunication.DoRequest(Server.SetGamePlanningTime(), form);
+	}
 
-    private void ServerChangePlanningRealTime(int newSeconds)
-    {
-        if (newSeconds < 10)
-            newSeconds = 10;
-        NetworkForm form = new NetworkForm();
-        form.AddField("realtime", newSeconds);
-        ServerCommunication.DoRequest(Server.SetRealPlanningTime(), form);
-    }
+	private void ServerChangePlanningRealTime(int newSeconds)
+	{
+		if (newSeconds < 10)
+			newSeconds = 10;
+		NetworkForm form = new NetworkForm();
+		form.AddField("realtime", newSeconds);
+		ServerCommunication.DoRequest(Server.SetRealPlanningTime(), form);
+	}
 
-    private void ServerChangeAllPlanningRealTime()
-    {
-        //Format era realtimes into comma separated string
-        string times = eraRealTimes[0].ToString();
-        for (int i = 1; i < eraRealTimes.Length; i++)
-            times += "," + eraRealTimes[i].ToString();
+	private void ServerChangeAllPlanningRealTime()
+	{
+		//Format era realtimes into comma separated string
+		string times = eraRealTimes[0].ToString();
+		for (int i = 1; i < eraRealTimes.Length; i++)
+			times += "," + eraRealTimes[i].ToString();
 
-        NetworkForm form = new NetworkForm();
-        form.AddField("realtime", times);
-        ServerCommunication.DoRequest(Server.SetFuturePlanningTime(), form);
-    }
+		NetworkForm form = new NetworkForm();
+		form.AddField("realtime", times);
+		ServerCommunication.DoRequest(Server.SetFuturePlanningTime(), form);
+	}
 
-    private void ServerChangeRemainingTime(int newSeconds)
-    {
-        if (newSeconds < 10)
-            newSeconds = 10;
-        NetworkForm form = new NetworkForm();
-        form.AddField("time", newSeconds);
-        ServerCommunication.DoRequest(Server.SetPlanningTimeRemaining(), form);
-    }
-    #endregion
+	private void ServerChangeRemainingTime(int newSeconds)
+	{
+		if (newSeconds < 10)
+			newSeconds = 10;
+		NetworkForm form = new NetworkForm();
+		form.AddField("time", newSeconds);
+		ServerCommunication.DoRequest(Server.SetPlanningTimeRemaining(), form);
+	}
+	#endregion
 }

--- a/Assets/Scripts/Interface/Time Manager/TimeManager.cs
+++ b/Assets/Scripts/Interface/Time Manager/TimeManager.cs
@@ -36,7 +36,7 @@ public class TimeManager : MonoBehaviour
 		}
 
 		m_timeLeftElapsed += Time.deltaTime;
-		EraHUD.instance.TimeRemaining = TimeSpan.FromSeconds(timeLeft - (int)m_timeLeftElapsed);
+		EraHUD.instance.TimeRemaining = TimeSpan.FromSeconds(Math.Max(timeLeft - (int)m_timeLeftElapsed, 0));
 	}
 
 	public void UpdateUI(TimelineState timeState)


### PR DESCRIPTION
Currently the "time left" shown in the game is updated when an update is received from the server. This means that it is necessary to receive an update each second when the game is in the planning state "play" since a countdown is shown at the top (otherwise is won't count down each second)

With this update the server does not necessarily need to sent an update each second since the client itself will do the
countdown. How does it work ?
* When an update is received, it will synchronize the "time left", that's not new.
* When an update is received, it will reset a local timer to 0
* If the planning state is "play", this timer will be increased by "deltaTime". So its value will be eqaul to "the elapsed seconds since the last update received"
* If the planning state is "play", the time left displayed, is the "time left since the last update received minus the elapsed time since that last update".

## Checklist before requesting a review
- [x] I am using the Jira issue number in the commit message.
- [x] The branch is named as the Jira issue number.
