### PR TITLE
MSP-3465 Close Game button of window shown after exception thrown doesn't work

### DIFF
--- a/Assets/Scripts/Utility/UncaughtExceptionReporter.cs
+++ b/Assets/Scripts/Utility/UncaughtExceptionReporter.cs
@@ -3,9 +3,8 @@ using System.Text;
 using UnityEngine;
 using UnityEngine.Networking;
 using Newtonsoft.Json;
-using GLog;
 
-class UncaughtExceptionReporter: MonoBehaviour
+class UncaughtExceptionReporter : MonoBehaviour
 {
 	private class AdditionalDebugInfo
 	{
@@ -131,7 +130,8 @@ class UncaughtExceptionReporter: MonoBehaviour
 			SubmitExceptionAnalytics(condition, stacktrace, "Error"); 
 		}
 	}
-
+	
+	//Test behavior of Quit button (Dev)
 	private void OnErrorDialogDismissed()
 	{
 		if (!Input.GetKey(KeyCode.RightShift))


### PR DESCRIPTION
Removed unused inclusion
Added comment explaining developer feature

## Checklist before requesting a review
- [x] I am using the Jira issue number in the commit message.
- [x] The branch is named as the Jira issue number.
