### PR TITLE
msp-3850 fix for RequestToken failures

### DIFF
--- a/Assets/Scripts/Interface/LogInMenu/LoginMenu.cs
+++ b/Assets/Scripts/Interface/LogInMenu/LoginMenu.cs
@@ -496,7 +496,8 @@ public class LoginMenu : MonoBehaviour
 		loginTeam.SetActive(false);
 
 		ServerCommunication.SetApiAccessToken(response.api_access_token, response.api_access_recovery_token);
-		TeamManager.InitializeUserValues(countryIndex, nameInputField.text, response.session_id, teamImporter.teams);
+		TeamManager.InitializeUserValues(countryIndex, nameInputField.text, response.session_id,
+			teamImporter.teams, passwordContainer.activeInHierarchy ? passwordInputField.text : null);
 		Main.MspGlobalData = teamImporter.MspGlobalData;
 
 		SceneManager.LoadScene("MSP2050");

--- a/Assets/Scripts/Interface/LogInMenu/LoginMenu.cs
+++ b/Assets/Scripts/Interface/LogInMenu/LoginMenu.cs
@@ -23,13 +23,6 @@ public class LoginMenu : MonoBehaviour
 	private static LoginMenu instance;
 	public static LoginMenu Instance => instance;
 
-	private class RequestSessionResponse
-	{
-		public int session_id = 0;
-		public string api_access_token = "";
-		public string api_access_recovery_token = "";
-	}
-
 	public GameObject loginServer;
 	public GameObject loginConnecting;
 	public GameObject loginTeam;
@@ -490,24 +483,13 @@ public class LoginMenu : MonoBehaviour
 			PlayerPrefs.SetInt(LOGIN_EXPERTISE_INDEX_STR, -1);
 
 		int countryIndex = teamsIDByCountryName[countryName];
-
-		string buildTime = null;
-		ApplicationBuildIdentifier buildIdentifier = ApplicationBuildIdentifier.FindBuildIdentifier();
-		if (buildIdentifier != null)
-		{
-			buildTime = buildIdentifier.GetBuildTime();
-		}
-
-		NetworkForm form = new NetworkForm();
-		form.AddField("country_id", countryIndex);
-		form.AddField("user_name", nameInputField.text);
-		if (passwordContainer.activeInHierarchy)
-			form.AddField("country_password", passwordInputField.text);
-		form.AddField("build_timestamp", buildTime);
-		ServerCommunication.DoRequest<RequestSessionResponse>(Server.RequestSession(), form, (response) => RequestSessionSuccess(response, countryIndex), RequestSessionFailure);
+		ServerCommunication.RequestSession(
+			countryIndex, nameInputField.text, (response) => RequestSessionSuccess(response, countryIndex),
+			RequestSessionFailure, passwordContainer.activeInHierarchy ? passwordInputField.text : null
+		);
 	}
 
-	void RequestSessionSuccess(RequestSessionResponse response, int countryIndex)
+	void RequestSessionSuccess(ServerCommunication.RequestSessionResponse response, int countryIndex)
 	{
 		//Continue to game
 		loginConnecting.SetActive(true);

--- a/Assets/Scripts/Networking/ApiTokenHandler.cs
+++ b/Assets/Scripts/Networking/ApiTokenHandler.cs
@@ -119,8 +119,8 @@ namespace Assets.Networking
 			requestSessionAttempts++;
 			int countryIndex = TeamManager.CurrentUserTeamID;
 			ServerCommunication.RequestSession(
-				countryIndex, TeamManager.CurrentUserName, RequestSessionSuccess, RequestSessionFailure
-				// we cannot re-new the Admin user since we do not know the password anymore. todo ?
+				countryIndex, TeamManager.CurrentUserName, RequestSessionSuccess, RequestSessionFailure,
+				TeamManager.Password
 			);
 		}
 

--- a/Assets/Scripts/Networking/ApiTokenHandler.cs
+++ b/Assets/Scripts/Networking/ApiTokenHandler.cs
@@ -36,9 +36,17 @@ namespace Assets.Networking
 		private DateTime lastTokenCheckTime = DateTime.MinValue;
 		private UnityWebRequest currentTokenRequest = null;
 		private UnityWebRequest renewTokenRequest = null;
+		private int requestSessionAttempts = 0;
+
+		private const int MAX_REQUEST_SESSION_ATTEMPTS = 10;
 
 		public void Update()
 		{
+			if (requestSessionAttempts > 0)
+			{
+				return;
+			}
+
 			if (renewTokenRequest != null)
 			{
 				HandleRenewTokenRequest();
@@ -106,6 +114,16 @@ namespace Assets.Networking
 			renewTokenRequest.SendWebRequest();
 		}
 
+		private void RequestSession()
+		{
+			requestSessionAttempts++;
+			int countryIndex = TeamManager.CurrentUserTeamID;
+			ServerCommunication.RequestSession(
+				countryIndex, TeamManager.CurrentUserName, RequestSessionSuccess, RequestSessionFailure
+				// we cannot re-new the Admin user since we do not know the password anymore. todo ?
+			);
+		}
+
 		private void HandleRenewTokenRequest()
 		{
 			if (renewTokenRequest.isDone)
@@ -123,7 +141,15 @@ namespace Assets.Networking
 					{
 						message += ", Request error: " + currentTokenRequest.error;
 					}
-					UnityEngine.Debug.LogError(message);
+					// only log warning, since this is not a fatal error just yet.
+					UnityEngine.Debug.LogWarning(message);
+
+					// renewal of access token might fail if token is older than 35 min
+					//   (=see Server's Security::TOKEN_DELETE_AFTER_TIME)
+					// This means the token details has been deleted, and the server cannot retrieve them anymore,
+					//   incl. its scope
+					// So in this case, create a completely new one session and token using "RequestSession" call.
+					RequestSession();
 				}
 
 				renewTokenRequest = null;
@@ -139,6 +165,28 @@ namespace Assets.Networking
 		public string GetAccessToken()
 		{
 			return currentAccessToken;
+		}
+
+		void RequestSessionSuccess(ServerCommunication.RequestSessionResponse response)
+		{
+			requestSessionAttempts = 0; // yes, user can continue playing
+			ServerCommunication.SetApiAccessToken(response.api_access_token, response.api_access_recovery_token);
+			TeamManager.CurrentSessionID = response.session_id;
+		}
+
+		void RequestSessionFailure(ServerCommunication.ARequest request, string message)
+		{
+			string msg = "Failed to request new session, request error: " + message;
+			if (requestSessionAttempts > MAX_REQUEST_SESSION_ATTEMPTS)
+			{
+				// fatal error, user has to quit the game
+				UnityEngine.Debug.LogError(msg);
+				throw new Exception(msg);
+			}
+
+			// only log warning, since this is not a fatal error just yet.
+			UnityEngine.Debug.LogWarning(msg);
+			RequestSession(); // try again
 		}
 	}
 }

--- a/Assets/Scripts/Networking/ServerCommunication.cs
+++ b/Assets/Scripts/Networking/ServerCommunication.cs
@@ -9,6 +9,7 @@ using Newtonsoft.Json.Serialization;
 using UnityEngine.Networking;
 using Utility.Serialization;
 using System.Text;
+using JetBrains.Annotations;
 
 public static class ServerCommunication
 {
@@ -18,6 +19,13 @@ public static class ServerCommunication
 
 	public const uint DEFAULT_MAX_REQUESTS = 5;
 	public static uint maxRequests = DEFAULT_MAX_REQUESTS;
+
+	public class RequestSessionResponse
+	{
+		public int session_id = 0;
+		public string api_access_token = "";
+		public string api_access_recovery_token = "";
+	}
 
 	public abstract class ARequest
 	{
@@ -544,5 +552,20 @@ public static class ServerCommunication
 	public static string GetApiAccessToken()
 	{
 		return tokenHandler.GetAccessToken();
+	}
+
+	public static void RequestSession(
+		int countryId, string userName, Action<RequestSessionResponse> successCallback,
+		System.Action<ARequest, string> failureCallback, [CanBeNull] string password = null)
+	{
+		NetworkForm form = new NetworkForm();
+		form.AddField("country_id", countryId);
+		form.AddField("user_name", userName);
+		if (password != null)
+		{
+			form.AddField("country_password", password);
+		}
+		form.AddField("build_timestamp", ApplicationBuildIdentifier.FindBuildIdentifier()?.GetBuildTime());
+		DoRequest(Server.RequestSession(), form, successCallback, failureCallback);
 	}
 }

--- a/Assets/Scripts/Users/TeamManager.cs
+++ b/Assets/Scripts/Users/TeamManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using JetBrains.Annotations;
 using UnityEngine;
 
 public static class TeamManager
@@ -14,6 +15,9 @@ public static class TeamManager
 	public static int CurrentSessionID { get; set; }
 	public static int CurrentUserTeamID { get; private set; }
 	public static string CurrentUserName { get; private set; }
+
+	[CanBeNull]
+	public static string Password { get; private set; }
 
 	public static bool AreWeGameMaster { get { return CurrentUserTeamID == GM_ID; } }
 	public static bool AreWeAreaManager { get { return CurrentUserTeamID == AM_ID; } }
@@ -95,12 +99,14 @@ public static class TeamManager
 		}
 	}
 
-	public static void InitializeUserValues(int userID, string userName, int sessionID, Dictionary<int, Team> aTeams)
+	public static void InitializeUserValues(int userID, string userName, int sessionID, Dictionary<int, Team> aTeams,
+		[CanBeNull] string password = null)
 	{
 		CurrentUserTeamID = userID;
 		CurrentUserName = userName;
 		CurrentSessionID = sessionID;
 		teamsByID = aTeams;
+		Password = password;
 	}
 
 	public static Team GetTeamByTeamID(int teamID)

--- a/Assets/Scripts/Users/TeamManager.cs
+++ b/Assets/Scripts/Users/TeamManager.cs
@@ -11,7 +11,7 @@ public static class TeamManager
 	private static Dictionary<string, Team> teamsByName = new Dictionary<string, Team>();
 
 	public static int TeamCount { get { return teamsByID.Count; } }
-	public static int CurrentSessionID { get; private set; }
+	public static int CurrentSessionID { get; set; }
 	public static int CurrentUserTeamID { get; private set; }
 	public static string CurrentUserName { get; private set; }
 


### PR DESCRIPTION
ok. The case to fix is when a laptop is set to suspend or hibernate, and resumed after more than 35 minutes in which case the token will be deleted , and the client attempts to call RequestToken which will fail.

Newly added: in such case we will re-request a session using the RequestSession call, given us a completely new token and session id.

Changes:
* core change: TeamManager::CurrentSessionId can now be written, it was read-only before.
* moved RequestSession call and RequestSessionResponse class from LoginMenu class to ServerCommunication class such that it can be used by multiple classes. Next to LoginMenu is will be used by ApiTokenHandler class
* added a extra level of token handling in ApiTokenHandler class. If renew token (RequestToken call) fails, it will do a call to RequestSession which needs to succeed to get a new token. If it fails again, it will re-try up to 10 times, after which it will throw an exception, the user has to quit the game.

todo: support re-request of session for Admin users using password. We will have to store the password in memory to be able to re-request a session. Might be unsafe, maybe do some encryption on it. Or just leave this as a known issue for admins ?

See corresponding Jira ticket to see videos testing the above