### PR TITLE
MSP-3893: Added a function to add issues directly to a deltaset if they're new, rather than having to be added to the issuemanager

### DIFF
--- a/Assets/Scripts/Interface/InterfaceCanvas.cs
+++ b/Assets/Scripts/Interface/InterfaceCanvas.cs
@@ -270,7 +270,8 @@ public class InterfaceCanvas : MonoBehaviour
 
 	public static void ShowNetworkingBlocker()
 	{
-		Instance.networkingBlocker.SetActive(true);
+		Instance.networkingBlocker.transform.SetAsLastSibling();
+        Instance.networkingBlocker.SetActive(true);
 	}
 
 	public static void HideNetworkingBlocker()

--- a/Assets/Scripts/Interface/Plans Monitor/Details/PlanDetails.cs
+++ b/Assets/Scripts/Interface/Plans Monitor/Details/PlanDetails.cs
@@ -146,7 +146,8 @@ public class PlanDetails : SerializedMonoBehaviour
 
 	public static void ChangeDate(Plan plan)
 	{
-		ConstraintManager.CheckConstraints(plan, null, false);
+		//Constraints should never need to be rechecked locally, except before submission -Kevin 10/05/22
+		//ConstraintManager.CheckConstraints(plan, null, false);
 
 		if (instance == null || instance.selectedPlan == null) return; //This window cant even be open so no point in updating anyways
 		if (plan == instance.selectedPlan)

--- a/Assets/Scripts/Interface/Time Bar/TimeBar.cs
+++ b/Assets/Scripts/Interface/Time Bar/TimeBar.cs
@@ -251,15 +251,15 @@ public class TimeBar : MonoBehaviour
 				{
 					if (updateWorldView)
 					{
-						//TODO
+						//TODO: if difference view is added
 						UpdateWorldViewingDifference();
 					}
 				}
                 else
                 {
-                    //TODO
-                }
-                break;
+					//TODO: if difference view is added
+				}
+				break;
 			case WorldViewMode.Normal:
 				collapsedDate.gameObject.SetActive(active);
 				layoutGroup.spacing = active ? 0 : 20f;
@@ -380,7 +380,7 @@ public class TimeBar : MonoBehaviour
 			//Max selectable year selected, limit month selection
 			if (selectedMonth > maxSelectableMonth)
 			{
-				monthDropdown.value = maxSelectableMonth; //TODO: maybe block callback here?
+				monthDropdown.value = maxSelectableMonth;
 			}
 			SetMonthDropdownOptions(monthDropdown, maxSelectableMonth, selectedMonth);
 		}
@@ -412,13 +412,13 @@ public class TimeBar : MonoBehaviour
 		{
 			UpdateIndicator(viewDifferenceIndicatorTop, time0);
 			UpdateIndicator(viewDifferenceIndicatorBottom, time1);
-			//TODO: set world to state
+			//TODO: if difference view is added: set world to state
 		}
 		else
 		{
 			UpdateIndicator(viewDifferenceIndicatorTop, time1);
 			UpdateIndicator(viewDifferenceIndicatorBottom, time0);
-			//TODO: set world to state
+			//TODO: if difference view is added: set world to state
 		}
 	}
 

--- a/Assets/Scripts/Issues/IssueManager.cs
+++ b/Assets/Scripts/Issues/IssueManager.cs
@@ -417,6 +417,18 @@ public class IssueManager : MonoBehaviour
 		}
 	}
 
+	public void AddIssuesToDeltaIfNew(MultiLayerRestrictionIssueCollection issueCollection, RestrictionIssueDeltaSet deltaSet)
+	{
+		foreach (var issueLayer in issueCollection.GetIssues())
+		{
+			for (int i = 0; i < issueLayer.Value.Count; ++i)
+			{
+				if (FindIssueByData(issueLayer.Key, issueLayer.Value[i]) == null)
+					deltaSet.IssueAdded(issueLayer.Value[i]);
+			}
+		}
+	}
+
 	public void OnIssuesReceived(WarningObject warningUpdateData)
 	{
 		foreach (PlanIssueObject planIssue in warningUpdateData.plan_issues)

--- a/Assets/Scripts/Issues/PlanIssueObject.cs
+++ b/Assets/Scripts/Issues/PlanIssueObject.cs
@@ -80,8 +80,6 @@ public class PlanIssueObject
 	public Plan GetSourcePlan()
 	{
         //Maybe we should cache this...
-        //return PlanManager.GetPlanAtIndex(source_plan_id);
-        //This used to get the plan by index... while using an ID. Seemed incorrect. -Kevin 4/6/18
         return PlanManager.GetPlanWithID(source_plan_id);
     }
 }


### PR DESCRIPTION
MSP-3893: Made the planswizard changes only calculate the issue delta set for submission, without applying them. Also resolved some issues with incorrect issue calculation.

MSP-3893: Cleanup and removal or of an unnecessary constraint check

MSP-3893: Moved the network blocker in front of the planswizard

## Checklist before requesting a review
- [ ] I am using the Jira issue number in the commit message.
- [ ] The branch is named as the Jira issue number.
