### PR TITLE
MSP-3986 fix missing initial fishing values (pt.1 of MSP-3986)

### DIFF
--- a/Assets/Scripts/Data Model/Ecology/FishingDistributionDelta.cs
+++ b/Assets/Scripts/Data Model/Ecology/FishingDistributionDelta.cs
@@ -51,6 +51,11 @@ namespace MSP2050.Scripts
 			values.Clear();
 		}
 
+		public bool HasFinishingValue(string fleetName)
+		{
+			return values.ContainsKey(fleetName);
+		}
+
 		public void SetFishingValue(string fleetName, int country, float fishingValue)
 		{
 			Dictionary<int, float> fleetValues;

--- a/Assets/Scripts/Data Model/PlanManager.cs
+++ b/Assets/Scripts/Data Model/PlanManager.cs
@@ -472,7 +472,6 @@ namespace MSP2050.Scripts
 			{
 				return; // already set.
 			}
-			initialFishingValues = new FishingDistributionDelta();
 			foreach (Plan plan in plans)
 			{
 				if (plan.fishingDistributionDelta == null)
@@ -482,9 +481,14 @@ namespace MSP2050.Scripts
 				foreach (KeyValuePair<string, Dictionary<int, float>> values in plan.fishingDistributionDelta.GetValuesByFleet())
 				{
 					var fleetName = values.Key;
-					if (initialFishingValues.HasFinishingValue(fleetName))
+					if (initialFishingValues != null && initialFishingValues.HasFinishingValue(fleetName))
 					{
 						continue; // already there, skip it
+					}
+					// gonna set fishing values, make sure initialFishingValues is initialised. Assuming a fleet always has values
+					if (initialFishingValues == null)
+					{
+						initialFishingValues = new FishingDistributionDelta();
 					}
 					foreach (var item in values.Value)
 					{

--- a/Assets/Scripts/Data Model/PlanManager.cs
+++ b/Assets/Scripts/Data Model/PlanManager.cs
@@ -1,8 +1,6 @@
 ﻿using System.Collections.Generic;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using UnityEngine;
-using UnityEngine.Networking;
 
 namespace MSP2050.Scripts
 {
@@ -465,8 +463,32 @@ namespace MSP2050.Scripts
 			return GetEnergyGridsBeforePlan(plans[plans.Count - 1], color, true);
 		}
 
+		private static void FixMissingInitialFishingValues()
+		{
+			foreach (Plan plan in plans)
+			{
+				if (plan.fishingDistributionDelta == null)
+				{
+					continue;
+				}
+				foreach (KeyValuePair<string, Dictionary<int, float>> values in plan.fishingDistributionDelta.GetValuesByFleet())
+				{
+					var fleetName = values.Key;
+					if (initialFishingValues.HasFinishingValue(fleetName))
+					{
+						continue; // already there, not need to fix any missing initial values
+					}
+					foreach (var item in values.Value)
+					{
+						initialFishingValues.SetFishingValue(fleetName, item.Key, item.Value); // add it the initial value
+					}
+				}
+			}
+		}
+
 		public static FishingDistributionSet GetFishingDistributionForPreviousPlan(Plan referencePlan)
 		{
+			FixMissingInitialFishingValues();
 			FishingDistributionSet result = new FishingDistributionSet(initialFishingValues);
 			foreach(Plan plan in plans)
 			{
@@ -488,6 +510,7 @@ namespace MSP2050.Scripts
 
 		public static FishingDistributionSet GetFishingDistributionAtTime(int timeMonth)
 		{
+			FixMissingInitialFishingValues();
 			FishingDistributionSet result = new FishingDistributionSet(initialFishingValues);
 			foreach (Plan plan in plans)
 			{

--- a/Assets/Scripts/Networking/Server.cs
+++ b/Assets/Scripts/Networking/Server.cs
@@ -479,11 +479,6 @@ namespace MSP2050.Scripts
 			return "api/game/Config";
 		}
 
-		public static string GetInitialFishingValues()
-		{
-			return "api/plan/GetInitialFishingValues";
-		}
-
 		public static string SetEnergyError()
 		{
 			return "api/plan/SetEnergyError";

--- a/Assets/Scripts/Plans/Plan.cs
+++ b/Assets/Scripts/Plans/Plan.cs
@@ -98,7 +98,7 @@ namespace MSP2050.Scripts
 			{
 				if (planObject.fishing == null)
 				{
-					fishingDistributionDelta = new FishingDistributionDelta(); //If null, it cant pick the right contructor automatically
+					fishingDistributionDelta = new FishingDistributionDelta(); //If null, it cant pick the right constructor automatically
 				}
 				else
 				{


### PR DESCRIPTION
flow:
```
handleImportLayerMetaCallback(List<LayerMeta> layerMeta) ->
ServerCommunication.DoRequest<JObject>(Server.GetMELConfig(), form, handleMELConfigCallback) ->
handleMELConfigCallback(JObject melConfig) ->
LoadFishingFleets(JObject melConfig) ->
LoadInitialFishingValues() ->
ServerCommunication.DoRequest<List<FishingObject>>(Server.GetInitialFishingValues(), form, LoadInitialFishingValuesCallback) ->
LoadInitialFishingValuesCallback(List<FishingObject> fishing) ->
initialFishingValues = new FishingDistributionDelta(fishing)
```

so the issue with this flow is that while MEL is launched, it will need some time to calculate the initial fishing values, and once it has, it will report this to the api using mel/InitialFishing call. However the client is already requesting this information after calling mel/Config, the initial fishing values might not be available yet resulting into an empty array.
Then later the method GetFishingDistributionAtTime(int timeMonth) is called with:
```
FishingDistributionSet result = new FishingDistributionSet(initialFishingValues);
result.ApplyValues(plan.fishingDistributionDelta);
```

with ApplyValues(FishingDistributionDelta deltaSet) having:
```
    foreach (KeyValuePair<string, Dictionary<int, float>> values in deltaSet.GetValuesByFleet())
    {
        Dictionary<int, float> target = fishingValues[values.Key];
```

and that will eventually crash because it is trying to access the initial fishing values using the values.Key which is not there, since fishingValues is empty.

So.... to handle this, I just accept the deltaSet values as being the initial values. This is handled by FixMissingInitialFishingValues
I think this is still correct. I mean, why not use the information we have already in the Latest update payload

todo: we can remove the fetch of the initial values entirely after the beta 10 release , and only use the data from the last update payload ?
Maybe the reason before was to have the initial fishing values fetched before any update data is retrieved, but the update data is pushed to the client as soon as it is ticked by the web socket server, so we do not need this separation anymore I think