### PR TITLE
MSP-4424

### DIFF
--- a/Assets/Scripts/Data Model/Energy/EnergyLineStringSubEntity.cs
+++ b/Assets/Scripts/Data Model/Energy/EnergyLineStringSubEntity.cs
@@ -74,7 +74,7 @@ namespace MSP2050.Scripts
 			//Delete cable
 			dataObject = new JObject();
 			dataObject.Add("cable", m_databaseID);
-			a_batch.AddRequest(Server.DeleteEnergyConection(), dataObject, BatchRequest.BATCH_GROUP_ENERGY_DELETE);
+			a_batch.AddRequest(Server.DeleteEnergyConnection(), dataObject, BatchRequest.BATCH_GROUP_ENERGY_DELETE);
 
 			return base.SubmitDelete(a_batch);
 		}

--- a/Assets/Scripts/Interface/Active Plans Window/AP_Approval.cs
+++ b/Assets/Scripts/Interface/Active Plans Window/AP_Approval.cs
@@ -26,7 +26,7 @@ namespace MSP2050.Scripts
 			RefreshContent(a_content);
 		}
 
-		void RefreshContent(Plan a_content)
+		public void RefreshContent(Plan a_content)
 		{
 			int nextIndex = 0;
 

--- a/Assets/Scripts/Interface/Active Plans Window/ActivePlanWindow.cs
+++ b/Assets/Scripts/Interface/Active Plans Window/ActivePlanWindow.cs
@@ -539,6 +539,10 @@ namespace MSP2050.Scripts
 			SetEntriesToPolicies();
 			SetEntriesToLayers();
 			RefreshSectionActivity();
+			if (m_approvalContent.IsOpen)
+			{
+				m_approvalContent.RefreshContent(m_currentPlan);
+			}
 		}
 
 		public void RefreshIssueText()

--- a/Assets/Scripts/Interface/Active Plans Window/ActivePlanWindow.cs
+++ b/Assets/Scripts/Interface/Active Plans Window/ActivePlanWindow.cs
@@ -267,7 +267,7 @@ namespace MSP2050.Scripts
 
 		private void SubmitChanges()
 		{
-			BatchRequest batch = new BatchRequest(true);
+			BatchRequest batch = new BatchRequest();
 
 			//Newly created plans are not locked
 			if (m_interactionMode != EInteractionMode.EditExisting)
@@ -302,7 +302,7 @@ namespace MSP2050.Scripts
 
 		void SubmitRestoration()
 		{
-			BatchRequest batch = new BatchRequest(true);
+			BatchRequest batch = new BatchRequest();
 			m_currentPlan.Description = m_planDescription.text;
 			m_currentPlan.Name = m_planName.text;
 			m_currentPlan.SendMessage("Restored the plans status to: " + Plan.PlanState.DESIGN.GetDisplayName(), batch);

--- a/Assets/Scripts/Interface/LogInMenu/RetrieveSessionListHandler.cs
+++ b/Assets/Scripts/Interface/LogInMenu/RetrieveSessionListHandler.cs
@@ -31,12 +31,12 @@ namespace MSP2050.Scripts
 		public IEnumerator RetrieveListAsync()
 		{
 			var hostnameToUse = hostname;
-			// note that Uri() only accepts "hostname" with a scheme, or without if :port is added,
-			//   but then it messes up parsing
-			// So to prevent errors, force scheme https manually, it there is no scheme			
+			// note that Uri() only accepts "hostname" with a scheme, or without the scheme if :port is added,
+			//   but then it messes up parsing, so to prevent errors, always force a scheme https if absent
 			if (!(hostname.StartsWith(Uri.UriSchemeHttp) || hostname.StartsWith(Uri.UriSchemeHttps)))
 			{
-				hostnameToUse = "https://" + hostname; // we use https as default
+				// we use https as default
+				hostnameToUse = "https://" + hostname;
 			}
 			
 			// This should not go wrong, and if it does we get an UriFormatException
@@ -44,7 +44,8 @@ namespace MSP2050.Scripts
 
 			var scheme = baseUrl.Scheme;
 			var host = baseUrl.Host;
-			var port = baseUrl.Port; // if a port was specified, use it, otherwise it will the default
+			// if a port was specified, use it, otherwise it will be the default
+			var port = baseUrl.Port;
 
 			var address = $"{scheme}://{host}:{port}/ServerManager/api/getsessionslist.php";
 			yield return TryRetrieveSessionList(address);

--- a/Assets/Scripts/Interface/LogInMenu/RetrieveSessionListHandler.cs
+++ b/Assets/Scripts/Interface/LogInMenu/RetrieveSessionListHandler.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections;
-using System.Security.Cryptography.X509Certificates;
-using System.Security.Policy;
 using UnityEngine;
 using UnityEngine.Networking;
 
@@ -32,20 +30,23 @@ namespace MSP2050.Scripts
 
 		public IEnumerator RetrieveListAsync()
 		{
-			UriBuilder baseUrl;
-			try
+			var hostnameToUse = hostname;
+			// note that Uri() only accepts "hostname" with a scheme, or without if :port is added,
+			//   but then it messes up parsing
+			// So to prevent errors, force scheme https manually, it there is no scheme			
+			if (!(hostname.StartsWith(Uri.UriSchemeHttp) || hostname.StartsWith(Uri.UriSchemeHttps)))
 			{
-				baseUrl = new UriBuilder(new Uri(hostname)); // not that Uri() only accepts "hostname" with a scheme
+				hostnameToUse = "https://" + hostname; // we use https as default
 			}
-			catch (UriFormatException e) // exception! meaning "hostname" does not include a scheme
-			{
-				// so create one. We use a secure base URL by default, unlike UriBuilder
-				baseUrl = new UriBuilder($"{Uri.UriSchemeHttps}://{hostname}");
-			}
-			string scheme = baseUrl.Scheme;
-			string host = baseUrl.Host;
+			
+			// This should not go wrong, and if it does we get an UriFormatException
+			UriBuilder baseUrl = new UriBuilder(new Uri(hostnameToUse));
 
-			string address = $"{scheme}://{host}/ServerManager/api/getsessionslist.php";
+			var scheme = baseUrl.Scheme;
+			var host = baseUrl.Host;
+			var port = baseUrl.Port; // if a port was specified, use it, otherwise it will the default
+
+			var address = $"{scheme}://{host}:{port}/ServerManager/api/getsessionslist.php";
 			yield return TryRetrieveSessionList(address);
 
 			// yes, we succeeded
@@ -56,8 +57,11 @@ namespace MSP2050.Scripts
 				yield break;
 			}
 
-			// ok, then let's try the insecure URL
-			address = $"{Uri.UriSchemeHttp}://{host}/ServerManager/api/getsessionslist.php";
+			// ok, then let's try the insecure URLs
+			// meaning, if we tried the default https port, then we need to switch to port 80 for http,
+			//   also meaning that if a non-default value was given, just try that again, but on a http scheme
+			if (port == 443) port = 80;
+			address = $"{Uri.UriSchemeHttp}://{host}:{port}/ServerManager/api/getsessionslist.php";
 			yield return TryRetrieveSessionList(address);
 		}
 

--- a/Assets/Scripts/Networking/BatchRequest.cs
+++ b/Assets/Scripts/Networking/BatchRequest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using UnityEngine;
@@ -33,17 +34,15 @@ namespace MSP2050.Scripts
 
 		public const int BATCH_GROUP_UNLOCK = 100;
 
-		private enum EBatchStatus { AwaitingBatchID, AwaitingExecutionIDs, AwaitingResults, Success, Failed }
+		private enum EBatchStatus { Setup, AwaitingResults, Success, Failed }
 
-		private EBatchStatus m_status = EBatchStatus.AwaitingBatchID;
-		private int m_batchID;
+		private EBatchStatus m_status = EBatchStatus.Setup;
+		private Guid m_batchGuid;
 		private int m_nextCallID = 1;
-		private bool m_executeWhenReady;
 		private bool m_async;
 
 		private Dictionary<int, ITypedCallback> m_callbacks; //callID to callback function
 		private List<QueuedBatchCall> m_callQueue; //Calls that are awaiting a batchID to be sent
-		private HashSet<int> m_outstandingCallRequests; //Calls that have been sent but not confirmed
 
 		private Action<BatchRequest> m_failureCallback;
 		private Action<BatchRequest> m_successCallback;
@@ -53,167 +52,58 @@ namespace MSP2050.Scripts
 			m_async = a_async;
 			m_callbacks = new Dictionary<int, ITypedCallback>();
 			m_callQueue = new List<QueuedBatchCall>();
-			m_outstandingCallRequests = new HashSet<int>();
 			NetworkForm form = new NetworkForm();
-			form.AddField("country_id", SessionManager.Instance.CurrentUserTeamID);
-			form.AddField("user_id", SessionManager.Instance.CurrentSessionID);
-			ServerCommunication.Instance.DoRequest<int>(Server.StartBatch(), form, HandleGetBatchIDSuccess, HandleGetBatchIDFailure);
-		}
-
-		private void HandleGetBatchIDSuccess(int a_newBatchID)
-		{
-			m_batchID = a_newBatchID;
-
-			m_status = EBatchStatus.AwaitingExecutionIDs;
-			foreach (QueuedBatchCall execution in m_callQueue)
-			{
-				SendRequest(execution.m_callID, execution.m_endPoint, execution.m_data, execution.m_group);
-			}
-			m_callQueue.Clear();
-		}
-
-		private void HandleGetBatchIDFailure(ARequest a_request, string a_message)
-		{
-			if (a_request.retriesRemaining > 0)
-			{
-				ServerCommunication.Instance.RetryRequest(a_request);
-			}
-			else
-			{
-				Debug.LogError($"Getting a batch ID failed. Error message: {a_message}");
-				m_status = EBatchStatus.Failed;
-				if (m_executeWhenReady)
-				{
-					ExecuteBatch();
-				}
-			}
+			m_batchGuid = Guid.NewGuid();
 		}
 
 		public int AddRequest(string a_endPoint, JObject a_data, int a_group)
 		{
-			if (m_status == EBatchStatus.Failed)
-				return -1;
-
+			if (m_status != EBatchStatus.Setup) return -1; // you can only add requests during Setup state
 			int id = m_nextCallID++;
-
-			//data.Add("user", TeamManager.CurrentSessionID);
-			if (m_status == EBatchStatus.AwaitingExecutionIDs)
-			{
-				SendRequest(id, a_endPoint, a_data.ToString(), a_group);
-			}
-			else
-			{
-				m_callQueue.Add(new QueuedBatchCall(id, a_endPoint, a_data.ToString(), a_group));
-			}
+			m_callQueue.Add(new QueuedBatchCall(id, a_endPoint, a_data.ToString(), a_group));
 			return id;
 		}
 
 		public int AddRequest<T>(string a_endPoint, JObject a_data, int a_group, Action<T> a_callback)
 		{
-			if (m_status == EBatchStatus.Failed)
-				return -1;
-
-			int id = m_nextCallID++;
+			int id = AddRequest(a_endPoint, a_data, a_group);
+			if (-1 == id) return -1;
 			if (a_callback != null)
 				m_callbacks.Add(id, new TypedCallback<T>(a_callback));
-
-			//data.Add("user", TeamManager.CurrentSessionID);
-			if (m_status == EBatchStatus.AwaitingExecutionIDs)
-			{
-				SendRequest(id, a_endPoint, a_data.ToString(), a_group);
-			}
-			else
-			{
-				m_callQueue.Add(new QueuedBatchCall(id, a_endPoint, a_data.ToString(), a_group));
-			}
 			return id;
-		}
-
-		private void SendRequest(int a_callID, string a_endPoint, string a_data, int a_group)
-		{
-			m_outstandingCallRequests.Add(a_callID);
-
-			NetworkForm form = new NetworkForm();
-			form.AddField("batch_id", m_batchID);
-			form.AddField("batch_group", a_group);
-			form.AddField("call_id", a_callID);
-			form.AddField("endpoint", a_endPoint);
-			form.AddField("endpoint_data", a_data);
-			ServerCommunication.Instance.DoRequest<int>(Server.AddToBatch(), form, HandleAddRequestSuccess, HandleAddRequestFailure);
-		}
-
-		private void HandleAddRequestSuccess(int a_callID)
-		{
-			m_outstandingCallRequests.Remove(a_callID);
-
-			if (m_executeWhenReady && m_outstandingCallRequests.Count == 0)
-			{
-				ExecuteBatch();
-			}
-		}
-
-		private void HandleAddRequestFailure(ARequest a_request, string a_message)
-		{
-			if (a_request.retriesRemaining > 0)
-			{
-				ServerCommunication.Instance.RetryRequest(a_request);
-			}
-			else
-			{
-				Debug.LogError($"Adding request to batch with ID {m_batchID} failed. Error message: {a_message}");
-				m_status = EBatchStatus.Failed;
-				if (m_executeWhenReady)
-				{
-					ExecuteBatch();
-				}
-			}
 		}
 
 		public void ExecuteBatch(Action<BatchRequest> a_successCallback, Action<BatchRequest> a_failureCallback)
 		{
+			if (m_status != EBatchStatus.Setup) return; // do not execute it again, once it is executed 
+			
 			m_successCallback = a_successCallback;
 			m_failureCallback = a_failureCallback;
-			ExecuteBatch();
-		}
+			
+			//All add requests are in, execute the batch
+			m_status = EBatchStatus.AwaitingResults;
 
-		private void ExecuteBatch()
-		{
-			if (m_status == EBatchStatus.Failed)
+			NetworkForm form = new NetworkForm();
+			form.AddField("country_id", SessionManager.Instance.CurrentUserTeamID);
+			form.AddField("user_id", SessionManager.Instance.CurrentSessionID);
+			form.AddField("batch_guid", m_batchGuid.ToString());
+			form.AddField("async", m_async.ToString());
+			form.AddField("requests", m_callQueue.Select(a_queuedBatchCall => new BatchSubRequest() {
+				call_id = a_queuedBatchCall.m_callID,
+				endpoint_data = a_queuedBatchCall.m_data,
+				endpoint = a_queuedBatchCall.m_endPoint,
+				group = a_queuedBatchCall.m_group
+			}));
+
+			if (m_async)
 			{
-				UpdateManager.Instance.WsServerCommunicationInteractor?.UnregisterBatchRequestCallbacks(m_batchID);
-
-				//Something caused the batch to already fail, call the failure callback directly
-				m_executeWhenReady = false;
-				Debug.LogError($"Batch with ID {m_batchID} could not be executed because a call during its setup failed.");
-				if (m_failureCallback != null)
-				{
-					m_failureCallback.Invoke(this);
-				}
-			}
-			else if (m_outstandingCallRequests.Count == 0 && m_status == EBatchStatus.AwaitingExecutionIDs)
-			{
-				//All add requests are in, execute the batch
-				m_executeWhenReady = false;
-				m_status = EBatchStatus.AwaitingResults;
-
-				NetworkForm form = new NetworkForm();
-				form.AddField("batch_id", m_batchID);
-				form.AddField("async", m_async.ToString());
-
-				if (m_async)
-				{
-					UpdateManager.Instance.WsServerCommunicationInteractor?.RegisterBatchRequestCallbacks(m_batchID, HandleBatchSuccess,
-						CreateHandleBatchFailureAction(ServerCommunication.Instance.DoRequest(Server.ExecuteBatch(), form))); // todo : handle error of executebatch
-				}
-				else
-				{
-					ServerCommunication.Instance.DoRequest<BatchExecutionResult>(Server.ExecuteBatch(), form, HandleBatchSuccess,
-						HandleBatchFailure);
-				}
+				UpdateManager.Instance.WsServerCommunicationInteractor?.RegisterBatchRequestCallbacks(m_batchGuid, HandleBatchSuccess,
+					CreateHandleBatchFailureAction(ServerCommunication.Instance.DoRequest(Server.ExecuteBatch(), form)));
 			}
 			else
 			{
-				m_executeWhenReady = true;
+				ServerCommunication.Instance.DoRequest<BatchExecutionResult>(Server.ExecuteBatch(), form, HandleBatchSuccess,
+					HandleBatchFailure);
 			}
 		}
 
@@ -222,12 +112,13 @@ namespace MSP2050.Scripts
 			return delegate(string a_message) {
 				if (a_request.retriesRemaining > 0)
 				{
+					m_status = EBatchStatus.AwaitingResults;				
 					ServerCommunication.Instance.RetryRequest(a_request);
 				}
 				else
 				{
-					UpdateManager.Instance.WsServerCommunicationInteractor?.UnregisterBatchRequestCallbacks(m_batchID);
-					Debug.LogError($"Batch with ID {m_batchID} failed. Error message: {a_message}");
+					UpdateManager.Instance.WsServerCommunicationInteractor?.UnregisterBatchRequestCallbacks(m_batchGuid);
+					Debug.LogError($"Batch with ID {m_batchGuid} failed. Error message: {a_message}");
 					m_status = EBatchStatus.Failed;
 					if (m_failureCallback != null)
 					{
@@ -258,7 +149,7 @@ namespace MSP2050.Scripts
 				m_successCallback.Invoke(this);
 			}
 
-			UpdateManager.Instance.WsServerCommunicationInteractor?.UnregisterBatchRequestCallbacks(m_batchID);
+			UpdateManager.Instance.WsServerCommunicationInteractor?.UnregisterBatchRequestCallbacks(m_batchGuid);
 		}
 
 		public static string FormatCallIDReference(int a_batchCallID, string a_field = null)
@@ -289,6 +180,15 @@ namespace MSP2050.Scripts
 			m_data = a_data;
 		}
 	}
+	
+	[SuppressMessage("ReSharper", "InconsistentNaming")]
+	struct BatchSubRequest
+	{
+		public int call_id;
+		public int group;
+		public string endpoint;
+		public string endpoint_data;
+	}	
 
 	[Serializable]
 	[SuppressMessage("ReSharper", "InconsistentNaming")] // needs to match json

--- a/Assets/Scripts/Networking/BatchRequest.cs
+++ b/Assets/Scripts/Networking/BatchRequest.cs
@@ -57,7 +57,8 @@ namespace MSP2050.Scripts
 
 		public int AddRequest(string a_endPoint, JObject a_data, int a_group)
 		{
-			if (m_status != EBatchStatus.Setup) return -1; // you can only add requests during Setup state
+			// you can only add requests during Setup state
+			if (m_status != EBatchStatus.Setup) return -1;
 			int id = m_nextCallID++;
 			m_callQueue.Add(new QueuedBatchCall(id, a_endPoint, a_data.ToString(), a_group));
 			return id;
@@ -74,7 +75,8 @@ namespace MSP2050.Scripts
 
 		public void ExecuteBatch(Action<BatchRequest> a_successCallback, Action<BatchRequest> a_failureCallback)
 		{
-			if (m_status != EBatchStatus.Setup) return; // do not execute it again, once it is executed 
+			// do not execute it again, once it is executed 
+			if (m_status != EBatchStatus.Setup) return;
 			
 			m_successCallback = a_successCallback;
 			m_failureCallback = a_failureCallback;

--- a/Assets/Scripts/Networking/BatchRequest.cs
+++ b/Assets/Scripts/Networking/BatchRequest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using UnityEngine;
@@ -33,16 +34,15 @@ namespace MSP2050.Scripts
 
 		public const int BATCH_GROUP_UNLOCK = 100;
 
-		private enum EBatchStatus { AwaitingBatchID, AwaitingExecutionIDs, AwaitingResults, Success, Failed }
+		private enum EBatchStatus { Setup, AwaitingResults, Success, Failed }
 
-		private EBatchStatus m_status = EBatchStatus.AwaitingBatchID;
-		private int m_batchID;
+		private EBatchStatus m_status = EBatchStatus.Setup;
+		private Guid m_batchGuid;
 		private int m_nextCallID = 1;
 		private bool m_executeWhenReady;
 
 		private Dictionary<int, ITypedCallback> m_callbacks; //callID to callback function
 		private List<QueuedBatchCall> m_callQueue; //Calls that are awaiting a batchID to be sent
-		private HashSet<int> m_outstandingCallRequests; //Calls that have been sent but not confirmed
 
 		private Action<BatchRequest> m_failureCallback;
 		private Action<BatchRequest> m_successCallback;
@@ -51,158 +51,49 @@ namespace MSP2050.Scripts
 		{
 			m_callbacks = new Dictionary<int, ITypedCallback>();
 			m_callQueue = new List<QueuedBatchCall>();
-			m_outstandingCallRequests = new HashSet<int>();
 			NetworkForm form = new NetworkForm();
-			form.AddField("country_id", SessionManager.Instance.CurrentUserTeamID);
-			form.AddField("user_id", SessionManager.Instance.CurrentSessionID);
-			ServerCommunication.Instance.DoRequest<int>(Server.StartBatch(), form, HandleGetBatchIDSuccess, HandleGetBatchIDFailure);
-		}
-
-		private void HandleGetBatchIDSuccess(int a_newBatchID)
-		{
-			m_batchID = a_newBatchID;
-
-			m_status = EBatchStatus.AwaitingExecutionIDs;
-			foreach (QueuedBatchCall execution in m_callQueue)
-			{
-				SendRequest(execution.m_callID, execution.m_endPoint, execution.m_data, execution.m_group);
-			}
-			m_callQueue.Clear();
-		}
-
-		private void HandleGetBatchIDFailure(ARequest a_request, string a_message)
-		{
-			if (a_request.retriesRemaining > 0)
-			{
-				ServerCommunication.Instance.RetryRequest(a_request);
-			}
-			else
-			{
-				Debug.LogError($"Getting a batch ID failed. Error message: {a_message}");
-				m_status = EBatchStatus.Failed;
-				if (m_executeWhenReady)
-				{
-					ExecuteBatch();
-				}
-			}
+			m_batchGuid = Guid.NewGuid();
 		}
 
 		public int AddRequest(string a_endPoint, JObject a_data, int a_group)
 		{
-			if (m_status == EBatchStatus.Failed)
-				return -1;
-
+			if (m_status != EBatchStatus.Setup) return -1; // you can only add requests during Setup state
 			int id = m_nextCallID++;
-
-			//data.Add("user", TeamManager.CurrentSessionID);
-			if (m_status == EBatchStatus.AwaitingExecutionIDs)
-			{
-				SendRequest(id, a_endPoint, a_data.ToString(), a_group);
-			}
-			else
-			{
-				m_callQueue.Add(new QueuedBatchCall(id, a_endPoint, a_data.ToString(), a_group));
-			}
+			m_callQueue.Add(new QueuedBatchCall(id, a_endPoint, a_data.ToString(), a_group));
 			return id;
 		}
 
 		public int AddRequest<T>(string a_endPoint, JObject a_data, int a_group, Action<T> a_callback)
 		{
-			if (m_status == EBatchStatus.Failed)
-				return -1;
-
-			int id = m_nextCallID++;
+			int id = AddRequest(a_endPoint, a_data, a_group);
+			if (-1 == id) return -1;
 			if (a_callback != null)
 				m_callbacks.Add(id, new TypedCallback<T>(a_callback));
-
-			//data.Add("user", TeamManager.CurrentSessionID);
-			if (m_status == EBatchStatus.AwaitingExecutionIDs)
-			{
-				SendRequest(id, a_endPoint, a_data.ToString(), a_group);
-			}
-			else
-			{
-				m_callQueue.Add(new QueuedBatchCall(id, a_endPoint, a_data.ToString(), a_group));
-			}
 			return id;
-		}
-
-		private void SendRequest(int a_callID, string a_endPoint, string a_data, int a_group)
-		{
-			m_outstandingCallRequests.Add(a_callID);
-
-			NetworkForm form = new NetworkForm();
-			form.AddField("batch_id", m_batchID);
-			form.AddField("batch_group", a_group);
-			form.AddField("call_id", a_callID);
-			form.AddField("endpoint", a_endPoint);
-			form.AddField("endpoint_data", a_data);
-			ServerCommunication.Instance.DoRequest<int>(Server.AddToBatch(), form, HandleAddRequestSuccess, HandleAddRequestFailure);
-		}
-
-		private void HandleAddRequestSuccess(int a_callID)
-		{
-			m_outstandingCallRequests.Remove(a_callID);
-
-			if (m_executeWhenReady && m_outstandingCallRequests.Count == 0)
-			{
-				ExecuteBatch();
-			}
-		}
-
-		private void HandleAddRequestFailure(ARequest a_request, string a_message)
-		{
-			if (a_request.retriesRemaining > 0)
-			{
-				ServerCommunication.Instance.RetryRequest(a_request);
-			}
-			else
-			{
-				Debug.LogError($"Adding request to batch with ID {m_batchID} failed. Error message: {a_message}");
-				m_status = EBatchStatus.Failed;
-				if (m_executeWhenReady)
-				{
-					ExecuteBatch();
-				}
-			}
 		}
 
 		public void ExecuteBatch(Action<BatchRequest> a_successCallback, Action<BatchRequest> a_failureCallback)
 		{
+			if (m_status != EBatchStatus.Setup) return; // do not execute it again, once it is executed 
+			
 			m_successCallback = a_successCallback;
 			m_failureCallback = a_failureCallback;
-			ExecuteBatch();
-		}
+			
+			//All add requests are in, execute the batch
+			m_status = EBatchStatus.AwaitingResults;
 
-		private void ExecuteBatch()
-		{
-			if (m_status == EBatchStatus.Failed)
-			{
-				UpdateManager.Instance.WsServerCommunicationInteractor?.UnregisterBatchRequestCallbacks(m_batchID);
-
-				//Something caused the batch to already fail, call the failure callback directly
-				m_executeWhenReady = false;
-				Debug.LogError($"Batch with ID {m_batchID} could not be executed because a call during its setup failed.");
-				if (m_failureCallback != null)
-				{
-					m_failureCallback.Invoke(this);
-				}
-			}
-			else if (m_outstandingCallRequests.Count == 0 && m_status == EBatchStatus.AwaitingExecutionIDs)
-			{
-				//All add requests are in, execute the batch
-				m_executeWhenReady = false;
-				m_status = EBatchStatus.AwaitingResults;
-
-				NetworkForm form = new NetworkForm();
-				form.AddField("batch_id", m_batchID);
-				UpdateManager.Instance.WsServerCommunicationInteractor?.RegisterBatchRequestCallbacks(m_batchID, HandleBatchSuccess,
-					CreateHandleBatchFailureAction(ServerCommunication.Instance.DoRequest(Server.ExecuteBatch(), form)));
-			}
-			else
-			{
-				m_executeWhenReady = true;
-			}
+			NetworkForm form = new NetworkForm();
+			form.AddField("country_id", SessionManager.Instance.CurrentUserTeamID);
+			form.AddField("user_id", SessionManager.Instance.CurrentSessionID);
+			form.AddField("batch_guid", m_batchGuid.ToString());
+			form.AddField("requests", m_callQueue.Select(a_queuedBatchCall => new BatchSubRequest() {
+				call_id = a_queuedBatchCall.m_callID,
+				endpoint_data = a_queuedBatchCall.m_data,
+				endpoint = a_queuedBatchCall.m_endPoint,
+				group = a_queuedBatchCall.m_group
+			}));
+			UpdateManager.Instance.WsServerCommunicationInteractor?.RegisterBatchRequestCallbacks(m_batchGuid, HandleBatchSuccess,
+				CreateHandleBatchFailureAction(ServerCommunication.Instance.DoRequest(Server.ExecuteBatch(), form)));
 		}
 
 		private Action<string> CreateHandleBatchFailureAction(ARequest a_request)
@@ -210,12 +101,13 @@ namespace MSP2050.Scripts
 			return delegate(string a_message) {
 				if (a_request.retriesRemaining > 0)
 				{
+					m_status = EBatchStatus.AwaitingResults;				
 					ServerCommunication.Instance.RetryRequest(a_request);
 				}
 				else
 				{
-					UpdateManager.Instance.WsServerCommunicationInteractor?.UnregisterBatchRequestCallbacks(m_batchID);
-					Debug.LogError($"Batch with ID {m_batchID} failed. Error message: {a_message}");
+					UpdateManager.Instance.WsServerCommunicationInteractor?.UnregisterBatchRequestCallbacks(m_batchGuid);
+					Debug.LogError($"Batch with ID {m_batchGuid} failed. Error message: {a_message}");
 					m_status = EBatchStatus.Failed;
 					if (m_failureCallback != null)
 					{
@@ -241,7 +133,7 @@ namespace MSP2050.Scripts
 				m_successCallback.Invoke(this);
 			}
 
-			UpdateManager.Instance.WsServerCommunicationInteractor?.UnregisterBatchRequestCallbacks(m_batchID);
+			UpdateManager.Instance.WsServerCommunicationInteractor?.UnregisterBatchRequestCallbacks(m_batchGuid);
 		}
 
 		public static string FormatCallIDReference(int a_batchCallID, string a_field = null)
@@ -272,6 +164,15 @@ namespace MSP2050.Scripts
 			m_data = a_data;
 		}
 	}
+	
+	[SuppressMessage("ReSharper", "InconsistentNaming")]
+	struct BatchSubRequest
+	{
+		public int call_id;
+		public int group;
+		public string endpoint;
+		public string endpoint_data;
+	}	
 
 	[Serializable]
 	[SuppressMessage("ReSharper", "InconsistentNaming")] // needs to match json

--- a/Assets/Scripts/Networking/Server.cs
+++ b/Assets/Scripts/Networking/Server.cs
@@ -524,16 +524,6 @@ namespace MSP2050.Scripts
 			return "api/security/RequestToken";
 		}
 
-		public static string StartBatch()
-		{
-			return "api/batch/StartBatch";
-		}
-
-		public static string AddToBatch()
-		{
-			return "api/batch/AddToBatch";
-		}
-
 		public static string ExecuteBatch()
 		{
 			return "api/batch/ExecuteBatch";

--- a/Assets/Scripts/Networking/Server.cs
+++ b/Assets/Scripts/Networking/Server.cs
@@ -310,7 +310,7 @@ namespace MSP2050.Scripts
 			return "api/energy/UpdateConnection";
 		}
 
-		public static string DeleteEnergyConection()
+		public static string DeleteEnergyConnection()
 		{
 			return "api/energy/DeleteConnection";
 		}

--- a/Assets/Scripts/Networking/Server.cs
+++ b/Assets/Scripts/Networking/Server.cs
@@ -524,6 +524,16 @@ namespace MSP2050.Scripts
 			return "api/security/RequestToken";
 		}
 
+		public static string StartBatch()
+		{
+			return "api/batch/StartBatch";
+		}
+
+		public static string AddToBatch()
+		{
+			return "api/batch/AddToBatch";
+		}
+
 		public static string ExecuteBatch()
 		{
 			return "api/batch/ExecuteBatch";

--- a/Assets/Scripts/Networking/WsServerCommunication.cs
+++ b/Assets/Scripts/Networking/WsServerCommunication.cs
@@ -7,8 +7,8 @@ using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 using UnityEngine;
 using Websocket.Client;
-using BatchRequestSuccessCallbacks = System.Collections.Generic.Dictionary<int, System.Action<MSP2050.Scripts.BatchExecutionResult>>;
-using BatchRequestFailureCallbacks = System.Collections.Generic.Dictionary<int, System.Action<string>>;
+using BatchRequestSuccessCallbacks = System.Collections.Generic.Dictionary<System.Guid, System.Action<MSP2050.Scripts.BatchExecutionResult>>;
+using BatchRequestFailureCallbacks = System.Collections.Generic.Dictionary<System.Guid, System.Action<string>>;
 using BatchRequestResultAndSuccessCallback =
 	System.Collections.Generic.KeyValuePair<MSP2050.Scripts.BatchExecutionResult, System.Action<MSP2050.Scripts.BatchExecutionResult>>;
 using BatchRequestResultAndFailureCallback = System.Collections.Generic.KeyValuePair<string, System.Action<string>>;
@@ -19,9 +19,9 @@ namespace MSP2050.Scripts
 	{
 		public void Start();
 		public void Stop();
-		public void RegisterBatchRequestCallbacks(int a_batchId, Action<BatchExecutionResult> a_successCallback,
+		public void RegisterBatchRequestCallbacks(Guid a_batchGuid, Action<BatchExecutionResult> a_successCallback,
 			System.Action<string> a_failureCallback);
-		public void UnregisterBatchRequestCallbacks(int a_batchId);
+		public void UnregisterBatchRequestCallbacks(Guid a_batchGuid);
 		public bool? IsConnected();
 	}
 
@@ -63,7 +63,7 @@ namespace MSP2050.Scripts
 		[SuppressMessage("ReSharper", "InconsistentNaming")] // need to match json
 		private class BatchRequestResultHeaderData
 		{
-			public int batch_id;
+			public Guid batch_guid;
 		}
 
 		public WsServerCommunication(int a_gameSessionId, int a_teamId, int a_userId,
@@ -149,23 +149,23 @@ namespace MSP2050.Scripts
 			}
 		}
 
-		public void RegisterBatchRequestCallbacks(int a_batchId, Action<BatchExecutionResult> a_successCallback,
+		public void RegisterBatchRequestCallbacks(Guid a_batchGuid, Action<BatchExecutionResult> a_successCallback,
 			Action<string> a_failureCallback)
 		{
-			UnregisterBatchRequestCallbacks(a_batchId);
-			m_batchRequestSuccessCallbacks.Add(a_batchId, a_successCallback);
-			m_batchRequestFailureCallbacks.Add(a_batchId, a_failureCallback);
+			UnregisterBatchRequestCallbacks(a_batchGuid);
+			m_batchRequestSuccessCallbacks.Add(a_batchGuid, a_successCallback);
+			m_batchRequestFailureCallbacks.Add(a_batchGuid, a_failureCallback);
 		}
 
-		public void UnregisterBatchRequestCallbacks(int a_batchId)
+		public void UnregisterBatchRequestCallbacks(Guid a_batchGuid)
 		{
-			if (m_batchRequestSuccessCallbacks.ContainsKey(a_batchId))
+			if (m_batchRequestSuccessCallbacks.ContainsKey(a_batchGuid))
 			{
-				m_batchRequestSuccessCallbacks.Remove(a_batchId);
+				m_batchRequestSuccessCallbacks.Remove(a_batchGuid);
 			}
-			if (m_batchRequestFailureCallbacks.ContainsKey(a_batchId))
+			if (m_batchRequestFailureCallbacks.ContainsKey(a_batchGuid))
 			{
-				m_batchRequestFailureCallbacks.Remove(a_batchId);
+				m_batchRequestFailureCallbacks.Remove(a_batchGuid);
 			}
 		}
 
@@ -195,7 +195,7 @@ namespace MSP2050.Scripts
 			{
 				BatchRequestResultAndFailureCallback pair =
 					new BatchRequestResultAndFailureCallback(a_result.message,
-						m_batchRequestFailureCallbacks[headerData.batch_id]);
+						m_batchRequestFailureCallbacks[headerData.batch_guid]);
 				m_batchRequestResultAndFailureCallbackQueue.Enqueue(pair);
 				return;
 			}
@@ -205,11 +205,11 @@ namespace MSP2050.Scripts
 				BatchExecutionResult batchExecutionResult = a_result.payload.ToObject<BatchExecutionResult>(serializer);
 				BatchRequestResultAndSuccessCallback pair =
 					new BatchRequestResultAndSuccessCallback(batchExecutionResult,
-						m_batchRequestSuccessCallbacks[headerData.batch_id]);
+						m_batchRequestSuccessCallbacks[headerData.batch_guid]);
 				m_batchRequestResultAndSuccessCallbackQueue.Enqueue(pair);
 			}
 
-			UnregisterBatchRequestCallbacks(headerData.batch_id);
+			UnregisterBatchRequestCallbacks(headerData.batch_guid);
 		}
 
 		private void ProcessGameLatestPayload(RequestResult a_result,


### PR DESCRIPTION
MSP-4424 No more separate StartBatch/AddToBatch api calls. They have been merged towards ExecuteBatch api call.

* simplified the ExecuteBatch call.
* no more separate StartBatch/AddToBatch api calls. There is only the "ExecuteBatch" api call which also starts the batch , and has a new "requests" parameter containing all the "AddToBatch" sub requests.
* To back reference a response to the created batch, a guid is generated and passed along with the execute batch.
* stripped a lot of code unnecessary.
* some improvements in the state handling, and guarding "add request" and execution of the batch while not in Setup state
* clean-up, no more AddToBatch /StartBatch
* batch request is always async now