### PR TITLE
fix crash on HandleRenewTokenRequest:

### DIFF
--- a/Assets/Scripts/Networking/ApiTokenHandler.cs
+++ b/Assets/Scripts/Networking/ApiTokenHandler.cs
@@ -89,12 +89,12 @@ namespace MSP2050.Scripts
 					if (requestSessionAttempts > MAX_REQUEST_SESSION_ATTEMPTS)
 					{
 						// fatal error, user has to quit the game
-						string msg = "Failed to request new API token, request error: " + response.message;
+						string msg = "Failed to request new API token, response message: " + response?.message;
 						Debug.LogError(msg);
 						throw new Exception(msg);
 					}
 
-					string message = "Failed to renew api access token. Message: " + response.message;
+					string message = "Failed to renew api access token. response message: " + response?.message;
 					if (refreshTokenRequest != null)
 					{
 						message += ", Request error: " + refreshTokenRequest.error;


### PR DESCRIPTION
NullReferenceException: Object reference not set to an instance of an object
  at MSP2050.Scripts.ApiTokenHandler.HandleRenewTokenRequest () [0x000e8] in C:\Jenkins\workspace\MSP_MSPChallenge-Client_dev\Assets\Scripts\Networking\ApiTokenHandler.cs:97
  at MSP2050.Scripts.ApiTokenHandler.Update () [0x0000f] in C:\Jenkins\workspace\MSP_MSPChallenge-Client_dev\Assets\Scripts\Networking\ApiTokenHandler.cs:48
  at MSP2050.Scripts.ServerCommunication.UpdateCommunication (System.Boolean updateToken) [0x00007] in C:\Jenkins\workspace\MSP_MSPChallenge-Client_dev\Assets\Scripts\Networking\ServerCommunication.cs:211
  at MSP2050.Scripts.Main.Update () [0x00013] in C:\Jenkins\workspace\MSP_MSPChallenge-Client_dev\Assets\Scripts\Main.cs:162

## Checklist before requesting a review
- [ ] I am using the Jira issue number in the commit message.
- [ ] The branch is named as the Jira issue number.
